### PR TITLE
Removed preprocessor registration from inside the gem

### DIFF
--- a/lib/metanorma-plugin-glossarist.rb
+++ b/lib/metanorma-plugin-glossarist.rb
@@ -9,8 +9,4 @@ module Metanorma
       # Your code goes here...
     end
   end
-
-  Asciidoctor::Extensions.register do
-    preprocessor Metanorma::Plugin::Glossarist::DatasetPreprocessor
-  end
 end


### PR DESCRIPTION
Removed preprocessor registration from inside the gem. This will be handled from inside the `Metanorma-standoc` gem