### PR TITLE
feat: raising error when liquid rendering fails

### DIFF
--- a/lib/metanorma/plugin/glossarist/document.rb
+++ b/lib/metanorma/plugin/glossarist/document.rb
@@ -26,7 +26,11 @@ module Metanorma
         def render_liquid(file_content)
           template = Liquid::Template.parse(file_content)
           template.registers[:file_system] = file_system
-          template.render(strict_variables: false, error_mode: :warn)
+          rendered_template = template.render(strict_variables: false, error_mode: :warn)
+
+          return rendered_template unless template.errors.any?
+
+          raise template.errors.first.cause
         end
       end
     end

--- a/spec/fixtures/invalid_dataset/concept-3.1.1.1.yaml
+++ b/spec/fixtures/invalid_dataset/concept-3.1.1.1.yaml
@@ -1,0 +1,26 @@
+---
+termid: 3.1.1.1
+term: entity
+eng:
+  terms:
+  - type: expression
+    normative_status: preferred
+    designation: entity
+  definition:
+  - content: concrete or abstract thing that exists, did exist, or can possibly exist,
+      including associations among these things
+  notes: []
+  examples:
+  - content: "{{person,Person}}, object, event, idea,
+      process, etc."
+  language_code: eng
+  entry_status: valid
+  sources:
+  - type: authoritative
+    origin:
+      ref: ISO/TS 14812:2022
+      clause: 3.1.1.1
+      link: https://www.iso.org/standard/79779.html
+
+  [.source]
+  <<ISO/TS 21308-4:2007>>

--- a/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
@@ -4,362 +4,385 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
   let(:document) { Asciidoctor::Document.new }
 
   describe "#process" do
-    context "[glossarist block]" do
-      context "[without filters]" do
+    context "Valid concepts" do
+      context "[glossarist block]" do
+        context "[without filters]" do
+          let(:reader) do
+            Asciidoctor::Reader.new <<~TEMPLATE
+              some text before glossarist block
+
+              === Section 1
+              [glossarist,./spec/fixtures/dataset1,concepts]
+              ----
+              ==== {{ concepts['entity'].term }}
+
+              {{ concepts['entity'].eng.definition[0].content }}
+              ----
+
+              some text after glossarist block
+            TEMPLATE
+          end
+
+          let(:expected_output) do
+            <<~OUTPUT.strip
+              some text before glossarist block
+
+              === Section 1
+
+              ==== entity
+
+              concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
+
+
+              some text after glossarist block
+            OUTPUT
+          end
+
+          it "should render correct output" do
+            expect(subject.process(document, reader).source).to eq(expected_output)
+          end
+        end
+
+        context "[with filters]" do
+          describe "filter='lang=ara'" do
+            let(:reader) do
+              Asciidoctor::Reader.new <<~TEMPLATE
+                some text before glossarist block
+
+                === Section 1
+                [glossarist,./spec/fixtures/dataset1,filter='lang=ara',concepts]
+                ----
+                {% for concept in concepts %}
+                ==== {{ concept.term }}
+
+                {{ concept.eng.definition[0].content }}
+                {% endfor %}
+                ----
+
+                some text after glossarist block
+              TEMPLATE
+            end
+
+            let(:expected_output) do
+              <<~OUTPUT.strip
+                some text before glossarist block
+
+                === Section 1
+
+
+
+
+                some text after glossarist block
+              OUTPUT
+            end
+
+            it "should render correct output" do
+              expect(subject.process(document, reader).source).to eq(expected_output)
+            end
+          end
+
+          describe "filter='sort_by=term'" do
+            let(:reader) do
+              Asciidoctor::Reader.new <<~TEMPLATE
+                some text before glossarist block
+
+                === Section 1
+                [glossarist,./spec/fixtures/dataset1,filter='sort_by=term',concepts]
+                ----
+                {% for concept in concepts %}
+                ==== {{ concept.term }}
+
+                {%- if concept.eng.terms.size > 1 %}
+                {%- for term in concept.eng.terms offset:1 %}
+                {% if term.normative_status %}{{ term.normative_status }}{% else %}alt{% endif %}:[{{ term.designation }}]
+                {%- endfor %}
+                {%- endif %}
+
+                {{ concept.eng.definition[0].content }}
+                {% endfor %}
+                ----
+
+                some text after glossarist block
+              TEMPLATE
+            end
+
+            let(:expected_output) do
+              <<~OUTPUT.strip
+                some text before glossarist block
+
+                === Section 1
+
+
+                ==== biological entity
+
+                {{material entity}} that was or is a living organism
+
+                ==== entity
+                admitted:[E]
+
+                concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
+
+                ==== material entity
+
+                {{entity}} that occupies three-dimensional space
+
+                ==== person
+
+                {{biological entity}} that is a human being
+
+
+
+                some text after glossarist block
+              OUTPUT
+            end
+
+            it "should render correct output" do
+              expect(subject.process(document, reader).source).to eq(expected_output)
+            end
+          end
+
+          describe "filter='group=foo;sort_by=term'" do
+            let(:reader) do
+              Asciidoctor::Reader.new <<~TEMPLATE
+                some text before glossarist block
+
+                === Section 1
+                [glossarist,./spec/fixtures/dataset1,filter='group=foo;sort_by=term',concepts]
+                ----
+                {% for concept in concepts %}
+                ==== {{ concept.term }}
+
+                {{ concept.eng.definition[0].content }}
+                {% endfor %}
+                ----
+
+                some text after glossarist block
+              TEMPLATE
+            end
+
+            let(:expected_output) do
+              <<~OUTPUT.strip
+                some text before glossarist block
+
+                === Section 1
+
+
+                ==== entity
+
+                concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
+
+                ==== material entity
+
+                {{entity}} that occupies three-dimensional space
+
+
+
+                some text after glossarist block
+              OUTPUT
+            end
+
+            it "should render correct output" do
+              expect(subject.process(document, reader).source).to eq(expected_output)
+            end
+          end
+
+          describe "filter='lang=eng;eng.terms.0.designation=entity'" do
+            let(:reader) do
+              Asciidoctor::Reader.new <<~TEMPLATE
+                some text before glossarist block
+
+                === Section 1
+                [glossarist,./spec/fixtures/dataset1,filter='lang=eng;eng.terms.0.designation=entity',concepts]
+                ----
+                {%- for concept in concepts -%}
+                ==== {{ concept.term }}
+
+                {{ concept.eng.definition[0].content }}
+                {%- endfor -%}
+                ----
+
+                some text after glossarist block
+              TEMPLATE
+            end
+
+            let(:expected_output) do
+              <<~OUTPUT.strip
+                some text before glossarist block
+
+                === Section 1
+                ==== entity
+
+                concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
+
+                some text after glossarist block
+              OUTPUT
+            end
+
+            it "should render correct output" do
+              expect(subject.process(document, reader).source).to eq(expected_output)
+            end
+          end
+
+          describe "filter='eng.terms.0.designation.start_with(enti)'" do
+            let(:reader) do
+              Asciidoctor::Reader.new <<~TEMPLATE
+                some text before glossarist block
+
+                === Section 1
+                [glossarist,./spec/fixtures/dataset1,filter='eng.terms.0.designation.start_with(enti)',concepts]
+                ----
+                {%- for concept in concepts -%}
+                ==== {{ concept.term }}
+
+                {{ concept.eng.definition[0].content }}
+                {%- endfor -%}
+                ----
+
+                some text after glossarist block
+              TEMPLATE
+            end
+
+            let(:expected_output) do
+              <<~OUTPUT.strip
+                some text before glossarist block
+
+                === Section 1
+                ==== entity
+
+                concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
+
+                some text after glossarist block
+              OUTPUT
+            end
+
+            it "should render correct output" do
+              expect(subject.process(document, reader).source).to eq(expected_output)
+            end
+          end
+        end
+      end
+
+      context "[load dataset]" do
         let(:reader) do
           Asciidoctor::Reader.new <<~TEMPLATE
-            some text before glossarist block
+            :glossarist-dataset: dataset1:./spec/fixtures/dataset1
 
-            === Section 1
-            [glossarist,./spec/fixtures/dataset1,concepts]
-            ----
-            ==== {{ concepts['entity'].term }}
-
-            {{ concepts['entity'].eng.definition[0].content }}
-            ----
-
-            some text after glossarist block
+            === Render Section
+            {{ dataset1['entity']['eng'].definition[0].content }}
           TEMPLATE
         end
 
         let(:expected_output) do
           <<~OUTPUT.strip
-            some text before glossarist block
-
-            === Section 1
-
-            ==== entity
-
+            === Render Section
             concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
-
-
-            some text after glossarist block
           OUTPUT
         end
 
         it "should render correct output" do
-          expect(subject.process(document, reader).source).to eq(expected_output)
+          expect(subject.process(document, reader).source.strip).to eq(expected_output)
         end
       end
 
-      context "[with filters]" do
-        describe "filter='lang=ara'" do
-          let(:reader) do
-            Asciidoctor::Reader.new <<~TEMPLATE
-              some text before glossarist block
+      context "[render concept]" do
+        let(:reader) do
+          Asciidoctor::Reader.new <<~TEMPLATE
+            :glossarist-dataset: dataset1:./spec/fixtures/dataset1
 
-              === Section 1
-              [glossarist,./spec/fixtures/dataset1,filter='lang=ara',concepts]
-              ----
-              {% for concept in concepts %}
-              ==== {{ concept.term }}
-
-              {{ concept.eng.definition[0].content }}
-              {% endfor %}
-              ----
-
-              some text after glossarist block
-            TEMPLATE
-          end
-
-          let(:expected_output) do
-            <<~OUTPUT.strip
-              some text before glossarist block
-
-              === Section 1
-
-
-
-
-              some text after glossarist block
-            OUTPUT
-          end
-
-          it "should render correct output" do
-            expect(subject.process(document, reader).source).to eq(expected_output)
-          end
+            === Render Section
+            glossarist::render[dataset1, entity]
+          TEMPLATE
         end
 
-        describe "filter='sort_by=term'" do
-          let(:reader) do
-            Asciidoctor::Reader.new <<~TEMPLATE
-              some text before glossarist block
+        let(:expected_output) do
+          <<~OUTPUT.strip
+            === Render Section
+            ==== entity
+            admitted:[E]
 
-              === Section 1
-              [glossarist,./spec/fixtures/dataset1,filter='sort_by=term',concepts]
-              ----
-              {% for concept in concepts %}
-              ==== {{ concept.term }}
-
-              {%- if concept.eng.terms.size > 1 %}
-              {%- for term in concept.eng.terms offset:1 %}
-              {% if term.normative_status %}{{ term.normative_status }}{% else %}alt{% endif %}:[{{ term.designation }}]
-              {%- endfor %}
-              {%- endif %}
-
-              {{ concept.eng.definition[0].content }}
-              {% endfor %}
-              ----
-
-              some text after glossarist block
-            TEMPLATE
-          end
-
-          let(:expected_output) do
-            <<~OUTPUT.strip
-              some text before glossarist block
-
-              === Section 1
+            concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
 
 
-              ==== biological entity
-
-              {{material entity}} that was or is a living organism
-
-              ==== entity
-              admitted:[E]
-
-              concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
-
-              ==== material entity
-
-              {{entity}} that occupies three-dimensional space
-
-              ==== person
-
-              {{biological entity}} that is a human being
+            [example]
+            {{person,Person}}, object, event, idea, process, etc.
 
 
 
-              some text after glossarist block
-            OUTPUT
-          end
 
-          it "should render correct output" do
-            expect(subject.process(document, reader).source).to eq(expected_output)
-          end
+
+
+
+
+            [.source]
+            <<ISO_TS_14812_2022,3.1.1.1>>
+          OUTPUT
         end
 
-        describe "filter='group=foo;sort_by=term'" do
-          let(:reader) do
-            Asciidoctor::Reader.new <<~TEMPLATE
-              some text before glossarist block
+        it "should render correct output" do
+          expect(subject.process(document, reader).source.strip).to eq(expected_output)
+        end
+      end
 
-              === Section 1
-              [glossarist,./spec/fixtures/dataset1,filter='group=foo;sort_by=term',concepts]
-              ----
-              {% for concept in concepts %}
-              ==== {{ concept.term }}
+      context "[render bibliography entry]" do
+        let(:reader) do
+          Asciidoctor::Reader.new <<~TEMPLATE
+            :glossarist-dataset: dataset1:./spec/fixtures/dataset1
 
-              {{ concept.eng.definition[0].content }}
-              {% endfor %}
-              ----
-
-              some text after glossarist block
-            TEMPLATE
-          end
-
-          let(:expected_output) do
-            <<~OUTPUT.strip
-              some text before glossarist block
-
-              === Section 1
-
-
-              ==== entity
-
-              concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
-
-              ==== material entity
-
-              {{entity}} that occupies three-dimensional space
-
-
-
-              some text after glossarist block
-            OUTPUT
-          end
-
-          it "should render correct output" do
-            expect(subject.process(document, reader).source).to eq(expected_output)
-          end
+            glossarist::render_bibliography_entry[dataset1, entity]
+          TEMPLATE
         end
 
-        describe "filter='lang=eng;eng.terms.0.designation=entity'" do
-          let(:reader) do
-            Asciidoctor::Reader.new <<~TEMPLATE
-              some text before glossarist block
-
-              === Section 1
-              [glossarist,./spec/fixtures/dataset1,filter='lang=eng;eng.terms.0.designation=entity',concepts]
-              ----
-              {%- for concept in concepts -%}
-              ==== {{ concept.term }}
-
-              {{ concept.eng.definition[0].content }}
-              {%- endfor -%}
-              ----
-
-              some text after glossarist block
-            TEMPLATE
-          end
-
-          let(:expected_output) do
-            <<~OUTPUT.strip
-              some text before glossarist block
-
-              === Section 1
-              ==== entity
-
-              concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
-
-              some text after glossarist block
-            OUTPUT
-          end
-
-          it "should render correct output" do
-            expect(subject.process(document, reader).source).to eq(expected_output)
-          end
+        let(:expected_output) do
+          <<~OUTPUT.strip
+            * [[[ISO_TS_14812_2022,ISO/TS 14812:2022]]]
+          OUTPUT
         end
 
-        describe "filter='eng.terms.0.designation.start_with(enti)'" do
-          let(:reader) do
-            Asciidoctor::Reader.new <<~TEMPLATE
-              some text before glossarist block
+        it "should render correct output" do
+          expect(subject.process(document, reader).source.strip).to eq(expected_output)
+        end
+      end
 
-              === Section 1
-              [glossarist,./spec/fixtures/dataset1,filter='eng.terms.0.designation.start_with(enti)',concepts]
-              ----
-              {%- for concept in concepts -%}
-              ==== {{ concept.term }}
+      context "[render bibliography]" do
+        let(:reader) do
+          Asciidoctor::Reader.new <<~TEMPLATE
+            :glossarist-dataset: dataset1:./spec/fixtures/dataset1
 
-              {{ concept.eng.definition[0].content }}
-              {%- endfor -%}
-              ----
+            glossarist::render_bibliography[dataset1]
+          TEMPLATE
+        end
 
-              some text after glossarist block
-            TEMPLATE
-          end
+        let(:expected_output) do
+          <<~OUTPUT.strip
+            * [[[ISO_TS_14812_2022,ISO/TS 14812:2022]]]
+            * [[[ISO_TS_14812_2023,ISO/TS 14812:2023]]]
+          OUTPUT
+        end
 
-          let(:expected_output) do
-            <<~OUTPUT.strip
-              some text before glossarist block
-
-              === Section 1
-              ==== entity
-
-              concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
-
-              some text after glossarist block
-            OUTPUT
-          end
-
-          it "should render correct output" do
-            expect(subject.process(document, reader).source).to eq(expected_output)
-          end
+        it "should render correct output" do
+          expect(subject.process(document, reader).source.strip).to eq(expected_output)
         end
       end
     end
 
-    context "[load dataset]" do
+    context "Invalid concepts" do
       let(:reader) do
         Asciidoctor::Reader.new <<~TEMPLATE
-          :glossarist-dataset: dataset1:./spec/fixtures/dataset1
+          some text before glossarist block
 
-          === Render Section
-          {{ dataset1['entity']['eng'].definition[0].content }}
+          === Section 1
+          [glossarist,./spec/fixtures/invalid_dataset,concepts]
+          ----
+          ==== {{ concepts['entity'].term }}
+
+          ----
+
+          some text after glossarist block
         TEMPLATE
       end
 
-      let(:expected_output) do
-        <<~OUTPUT.strip
-          === Render Section
-          concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
-        OUTPUT
-      end
-
-      it "should render correct output" do
-        expect(subject.process(document, reader).source.strip).to eq(expected_output)
-      end
-    end
-
-    context "[render concept]" do
-      let(:reader) do
-        Asciidoctor::Reader.new <<~TEMPLATE
-          :glossarist-dataset: dataset1:./spec/fixtures/dataset1
-
-          === Render Section
-          glossarist::render[dataset1, entity]
-        TEMPLATE
-      end
-
-      let(:expected_output) do
-        <<~OUTPUT.strip
-          === Render Section
-          ==== entity
-          admitted:[E]
-
-          concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
-
-
-          [example]
-          {{person,Person}}, object, event, idea, process, etc.
-
-
-
-
-
-
-
-
-          [.source]
-          <<ISO_TS_14812_2022,3.1.1.1>>
-        OUTPUT
-      end
-
-      it "should render correct output" do
-        expect(subject.process(document, reader).source.strip).to eq(expected_output)
-      end
-    end
-
-    context "[render bibliography entry]" do
-      let(:reader) do
-        Asciidoctor::Reader.new <<~TEMPLATE
-          :glossarist-dataset: dataset1:./spec/fixtures/dataset1
-
-          glossarist::render_bibliography_entry[dataset1, entity]
-        TEMPLATE
-      end
-
-      let(:expected_output) do
-        <<~OUTPUT.strip
-          * [[[ISO_TS_14812_2022,ISO/TS 14812:2022]]]
-        OUTPUT
-      end
-
-      it "should render correct output" do
-        expect(subject.process(document, reader).source.strip).to eq(expected_output)
-      end
-    end
-
-    context "[render bibliography]" do
-      let(:reader) do
-        Asciidoctor::Reader.new <<~TEMPLATE
-          :glossarist-dataset: dataset1:./spec/fixtures/dataset1
-
-          glossarist::render_bibliography[dataset1]
-        TEMPLATE
-      end
-
-      let(:expected_output) do
-        <<~OUTPUT.strip
-          * [[[ISO_TS_14812_2022,ISO/TS 14812:2022]]]
-          * [[[ISO_TS_14812_2023,ISO/TS 14812:2023]]]
-        OUTPUT
-      end
-
-      it "should render correct output" do
-        expect(subject.process(document, reader).source.strip).to eq(expected_output)
+      it "is expected to raise Glossarist::ParseError" do
+        expect { subject.process(document, reader) }.to raise_error(Glossarist::ParseError)
       end
     end
   end


### PR DESCRIPTION
Raising an error when liquid rendering fails

**Need to merge the following PR and release a new version of glossarist before merging this PR**
- [x] https://github.com/glossarist/glossarist-ruby/pull/72


fixes https://github.com/glossarist/glossarist-ruby/issues/71