### PR TITLE
Lock Glossarist to model V1

### DIFF
--- a/metanorma-plugin-glossarist.gemspec
+++ b/metanorma-plugin-glossarist.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "asciidoctor", "~> 2.0.0"
-  spec.add_dependency "glossarist"
+  spec.add_dependency "glossarist", "~> 1.1.0"
   spec.add_dependency "liquid", "~> 5"
 
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Current version of `metanorma-plugin-glossarist` will not work with `Glossarist model v2` so locking it to V1 until the code is updated.