### PR TITLE
skip source if ref is empty

### DIFF
--- a/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
+++ b/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
@@ -202,7 +202,7 @@ module Metanorma
           bibliography = concept["eng"]["sources"].map do |source|
             ref = source["origin"]["ref"]
 
-            next if @rendered_bibliographies[ref]
+            next if @rendered_bibliographies[ref] || ref.nil? || ref.empty?
 
             @rendered_bibliographies[ref] = ref.gsub(/[ \/:]/, "_")
             "* [[[#{@rendered_bibliographies[ref]},#{ref}]]]"
@@ -289,6 +289,7 @@ module Metanorma
         def sources(dataset_name, concept_name)
           <<~SOURCES
             {% for source in #{dataset_name}['#{concept_name}']['eng'].sources %}
+            {%- if source.origin.ref == nil or source.origin.ref == '' %}{% continue %}{% endif %}
             [.source]
             <<{{ source.origin.ref | replace: ' ', '_' | replace: '/', '_' | replace: ':', '_' }},{{ source.origin.clause }}>>
 

--- a/spec/fixtures/dataset-glossarist-v2/localized_concept/ccceb779-456f-5115-926d-44487324d4bb.yaml
+++ b/spec/fixtures/dataset-glossarist-v2/localized_concept/ccceb779-456f-5115-926d-44487324d4bb.yaml
@@ -21,3 +21,6 @@ data:
       ref: ISO/TS 14812:2022
       clause: 3.1.1.1
       link: https://www.iso.org/standard/79779.html
+  - type: lineage
+    origin:
+      ref: ''


### PR DESCRIPTION
`[.source]` is suppressed from the output If `sources.origin.ref` is empty.

closes #30 
