### PR TITLE
feat: allow anchor-prefix in render tag

### DIFF
--- a/lib/liquid/custom_filters/filters.rb
+++ b/lib/liquid/custom_filters/filters.rb
@@ -5,6 +5,12 @@ module Liquid
         list.values
       end
 
+      def sanitize_references(str)
+        str.gsub(/\{\{([^,]*),([^\}]*)\}\}/) do |match|
+          "{{#{Metanorma::Utils.to_ncname(Regexp.last_match[1])},#{Regexp.last_match[2]}}}"
+        end
+      end
+
       def terminological_data(term)
         result = []
 

--- a/lib/metanorma-plugin-glossarist.rb
+++ b/lib/metanorma-plugin-glossarist.rb
@@ -1,6 +1,7 @@
 require "metanorma/plugin/glossarist/version"
 require "metanorma/plugin/glossarist/document"
 require "metanorma/plugin/glossarist/dataset_preprocessor"
+require "metanorma-utils"
 
 module Metanorma
   module Plugin

--- a/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
+++ b/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
@@ -266,7 +266,7 @@ module Metanorma
         def identifier(dataset_name, concept_name, options = {})
           prefix = "#{options["anchor-prefix"]}" if options["anchor-prefix"]
 
-          "#{prefix}#{@datasets[dataset_name][concept_name]["identifier"]}"
+          Metanorma::Utils.to_ncname("#{prefix}#{@datasets[dataset_name][concept_name]["identifier"]}")
         end
 
         def options_to_hash(options_arr)

--- a/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
+++ b/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
@@ -60,7 +60,7 @@ module Metanorma
           super
           @config = config
           @datasets = {}
-          @title_depth = 2
+          @title_depth = { value: 2 }
           @rendered_bibliographies = {}
         end
 
@@ -110,7 +110,7 @@ module Metanorma
           elsif match = current_line.match(GLOSSARIST_BLOCK_REGEX)
             process_glossarist_block(document, liquid_doc, input_lines, match)
           else
-            @title_depth = current_line.sub(/ .*$/, "").size if /^==+ \S/.match?(current_line)
+            @title_depth[:value] = current_line.sub(/ .*$/, "").size if /^==+ \S/.match?(current_line)
             liquid_doc.add_content(current_line)
           end
         end
@@ -239,7 +239,7 @@ module Metanorma
 
         def concept_template(dataset_name, concept_name)
           <<~CONCEPT_TEMPLATE
-            #{"=" * (@title_depth + 1)} {{ #{dataset_name}['#{concept_name}'].term }}
+            #{"=" * (@title_depth[:value] + 1)} {{ #{dataset_name}['#{concept_name}'].term }}
             #{alt_terms(dataset_name, concept_name)}
 
             {{ #{dataset_name}['#{concept_name}']['eng'].definition[0].content }}

--- a/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
+++ b/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
@@ -60,6 +60,7 @@ module Metanorma
           super
           @config = config
           @datasets = {}
+          @title_depth = 2
           @rendered_bibliographies = {}
         end
 
@@ -109,6 +110,7 @@ module Metanorma
           elsif match = current_line.match(GLOSSARIST_BLOCK_REGEX)
             process_glossarist_block(document, liquid_doc, input_lines, match)
           else
+            @title_depth = current_line.sub(/ .*$/, "").size if /^==+ \S/.match?(current_line)
             liquid_doc.add_content(current_line)
           end
         end
@@ -237,7 +239,7 @@ module Metanorma
 
         def concept_template(dataset_name, concept_name)
           <<~CONCEPT_TEMPLATE
-            ==== {{ #{dataset_name}['#{concept_name}'].term }}
+            #{"=" * (@title_depth + 1)} {{ #{dataset_name}['#{concept_name}'].term }}
             #{alt_terms(dataset_name, concept_name)}
 
             {{ #{dataset_name}['#{concept_name}']['eng'].definition[0].content }}

--- a/metanorma-plugin-glossarist.gemspec
+++ b/metanorma-plugin-glossarist.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "asciidoctor", "~> 2.0.0"
   spec.add_dependency "glossarist", "~> 2.0.1"
   spec.add_dependency "liquid", "~> 5"
+  spec.add_dependency "metanorma-utils", "~> 1.10"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/spec/fixtures/dataset-glossarist-v2/localized_concept/c8763b71-b695-5117-9309-c7d998f63ad7.yaml
+++ b/spec/fixtures/dataset-glossarist-v2/localized_concept/c8763b71-b695-5117-9309-c7d998f63ad7.yaml
@@ -4,7 +4,7 @@ data:
     normative_status: preferred
     designation: material entity
   definition:
-  - content: "{{entity}} that occupies three-dimensional
+  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that occupies three-dimensional
       space"
   notes:
   - content: All material entities have certain characteristics that can be described

--- a/spec/fixtures/dataset-glossarist-v2/localized_concept/ccceb779-456f-5115-926d-44487324d4bb.yaml
+++ b/spec/fixtures/dataset-glossarist-v2/localized_concept/ccceb779-456f-5115-926d-44487324d4bb.yaml
@@ -11,7 +11,7 @@ data:
       including associations among these things
   notes: []
   examples:
-  - content: "{{person,Person}}, object, event, idea,
+  - content: "{{urn:iso:std:iso:14812:3.1.1.6,person,Person}}, object, event, idea,
       process, etc."
   language_code: eng
   entry_status: valid

--- a/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
@@ -333,6 +333,110 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
         end
       end
 
+      context "[render dataset]" do
+        let(:reader) do
+          Asciidoctor::Reader.new <<~TEMPLATE
+            :glossarist-dataset: dataset1:./spec/fixtures/dataset-glossarist-v2
+
+            === Terms and Definitions
+            glossarist::import[dataset1,anchor-prefix=urn:iso:std:iso:14812:]
+          TEMPLATE
+        end
+
+        let(:expected_output) do
+          <<~OUTPUT.strip
+            === Terms and Definitions
+            [[urn:iso:std:iso:14812:3.1.1.5]]
+            ==== biological entity
+
+
+            {{material entity}} that was or is a living organism
+
+
+
+
+
+
+
+
+            [.source]
+            <<ISO_TS_14812_2023,3.1.1.5>>
+
+
+
+
+            [[urn:iso:std:iso:14812:3.1.1.1]]
+            ==== entity
+            admitted:[E]
+
+            concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
+
+
+            [example]
+            {{person,Person}}, object, event, idea, process, etc.
+
+
+
+
+
+
+
+
+            [.source]
+            <<ISO_TS_14812_2022,3.1.1.1>>
+
+
+
+
+            [[urn:iso:std:iso:14812:3.1.1.3]]
+            ==== material entity
+
+
+            {{entity}} that occupies three-dimensional space
+
+
+
+
+
+            [NOTE]
+            ====
+            All material entities have certain characteristics that can be described and therefore this concept is important for ontology purposes.
+            ====
+
+
+
+
+
+            [.source]
+            <<ISO_TS_14812_2022,3.1.1.3>>
+
+
+
+
+            [[urn:iso:std:iso:14812:3.1.1.6]]
+            ==== person
+
+
+            {{biological entity}} that is a human being
+
+
+
+
+
+
+
+
+            [.source]
+            <<ISO_TS_14812_2022,3.1.1.6>>
+          OUTPUT
+        end
+
+        it "should render correct output" do
+          expect(subject.process(document, reader).source.strip)
+            .to eq(expected_output)
+        end
+      end
+
       context "[render concept]" do
         context "with 3 level title depth" do
           let(:reader) do
@@ -347,6 +451,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
           let(:expected_output) do
             <<~OUTPUT.strip
               === Render Section
+              [[3.1.1.1]]
               ==== entity
               admitted:[E]
 
@@ -387,6 +492,48 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
           let(:expected_output) do
             <<~OUTPUT.strip
               == Render Section
+              [[3.1.1.1]]
+              === entity
+              admitted:[E]
+
+              concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
+
+
+              [example]
+              {{person,Person}}, object, event, idea, process, etc.
+
+
+
+
+
+
+
+
+              [.source]
+              <<ISO_TS_14812_2022,3.1.1.1>>
+            OUTPUT
+          end
+
+          it "should render correct output" do
+            expect(subject.process(document, reader).source.strip)
+              .to eq(expected_output)
+          end
+        end
+
+        context "with anchor-prefix" do
+          let(:reader) do
+            Asciidoctor::Reader.new <<~TEMPLATE
+              :glossarist-dataset: dataset1:./spec/fixtures/dataset-glossarist-v2
+
+              == Render Section
+              glossarist::render[dataset1, entity, anchor-prefix=identifier-]
+            TEMPLATE
+          end
+
+          let(:expected_output) do
+            <<~OUTPUT.strip
+              == Render Section
+              [[identifier-3.1.1.1]]
               === entity
               admitted:[E]
 

--- a/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
         let(:expected_output) do
           <<~OUTPUT.strip
             === Terms and Definitions
-            [[urn:iso:std:iso:14812:3.1.1.5]]
+            [[urn_iso_std_iso_14812_3.1.1.5]]
             ==== biological entity
 
 
@@ -365,7 +365,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
 
 
 
-            [[urn:iso:std:iso:14812:3.1.1.1]]
+            [[urn_iso_std_iso_14812_3.1.1.1]]
             ==== entity
             admitted:[E]
 
@@ -388,7 +388,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
 
 
 
-            [[urn:iso:std:iso:14812:3.1.1.3]]
+            [[urn_iso_std_iso_14812_3.1.1.3]]
             ==== material entity
 
 
@@ -413,7 +413,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
 
 
 
-            [[urn:iso:std:iso:14812:3.1.1.6]]
+            [[urn_iso_std_iso_14812_3.1.1.6]]
             ==== person
 
 
@@ -451,7 +451,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
           let(:expected_output) do
             <<~OUTPUT.strip
               === Render Section
-              [[3.1.1.1]]
+              [[_3.1.1.1]]
               ==== entity
               admitted:[E]
 
@@ -492,7 +492,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
           let(:expected_output) do
             <<~OUTPUT.strip
               == Render Section
-              [[3.1.1.1]]
+              [[_3.1.1.1]]
               === entity
               admitted:[E]
 

--- a/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
 
                 ==== material entity
 
-                {{entity}} that occupies three-dimensional space
+                {{urn_iso_std_iso_14812_3.1.1.1,entity}} that occupies three-dimensional space
 
                 ==== person
 
@@ -218,7 +218,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
 
                 ==== material entity
 
-                {{entity}} that occupies three-dimensional space
+                {{urn_iso_std_iso_14812_3.1.1.1,entity}} that occupies three-dimensional space
 
 
 
@@ -373,7 +373,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
 
 
             [example]
-            {{person,Person}}, object, event, idea, process, etc.
+            {{urn_iso_std_iso_14812_3.1.1.6,person,Person}}, object, event, idea, process, etc.
 
 
 
@@ -392,7 +392,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
             ==== material entity
 
 
-            {{entity}} that occupies three-dimensional space
+            {{urn_iso_std_iso_14812_3.1.1.1,entity}} that occupies three-dimensional space
 
 
 
@@ -459,7 +459,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
 
 
               [example]
-              {{person,Person}}, object, event, idea, process, etc.
+              {{urn_iso_std_iso_14812_3.1.1.6,person,Person}}, object, event, idea, process, etc.
 
 
 
@@ -500,7 +500,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
 
 
               [example]
-              {{person,Person}}, object, event, idea, process, etc.
+              {{urn_iso_std_iso_14812_3.1.1.6,person,Person}}, object, event, idea, process, etc.
 
 
 
@@ -541,7 +541,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
 
 
               [example]
-              {{person,Person}}, object, event, idea, process, etc.
+              {{urn_iso_std_iso_14812_3.1.1.6,person,Person}}, object, event, idea, process, etc.
 
 
 

--- a/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
@@ -334,26 +334,67 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
       end
 
       context "[render concept]" do
-        let(:reader) do
-          Asciidoctor::Reader.new <<~TEMPLATE
-            :glossarist-dataset: dataset1:./spec/fixtures/dataset-glossarist-v2
+        context "with 3 level title depth" do
+          let(:reader) do
+            Asciidoctor::Reader.new <<~TEMPLATE
+              :glossarist-dataset: dataset1:./spec/fixtures/dataset-glossarist-v2
 
-            === Render Section
-            glossarist::render[dataset1, entity]
-          TEMPLATE
+              === Render Section
+              glossarist::render[dataset1, entity]
+            TEMPLATE
+          end
+
+          let(:expected_output) do
+            <<~OUTPUT.strip
+              === Render Section
+              ==== entity
+              admitted:[E]
+
+              concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
+
+
+              [example]
+              {{person,Person}}, object, event, idea, process, etc.
+
+
+
+
+
+
+
+
+              [.source]
+              <<ISO_TS_14812_2022,3.1.1.1>>
+            OUTPUT
+          end
+
+          it "should render correct output" do
+            expect(subject.process(document, reader).source.strip)
+              .to eq(expected_output)
+          end
         end
 
-        let(:expected_output) do
-          <<~OUTPUT.strip
-            === Render Section
-            ==== entity
-            admitted:[E]
+        context "with 2 level title depth" do
+          let(:reader) do
+            Asciidoctor::Reader.new <<~TEMPLATE
+              :glossarist-dataset: dataset1:./spec/fixtures/dataset-glossarist-v2
 
-            concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
+              == Render Section
+              glossarist::render[dataset1, entity]
+            TEMPLATE
+          end
+
+          let(:expected_output) do
+            <<~OUTPUT.strip
+              == Render Section
+              === entity
+              admitted:[E]
+
+              concrete or abstract thing that exists, did exist, or can possibly exist, including associations among these things
 
 
-            [example]
-            {{person,Person}}, object, event, idea, process, etc.
+              [example]
+              {{person,Person}}, object, event, idea, process, etc.
 
 
 
@@ -362,14 +403,15 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
 
 
 
-            [.source]
-            <<ISO_TS_14812_2022,3.1.1.1>>
-          OUTPUT
-        end
+              [.source]
+              <<ISO_TS_14812_2022,3.1.1.1>>
+            OUTPUT
+          end
 
-        it "should render correct output" do
-          expect(subject.process(document, reader).source.strip)
-            .to eq(expected_output)
+          it "should render correct output" do
+            expect(subject.process(document, reader).source.strip)
+              .to eq(expected_output)
+          end
         end
       end
 


### PR DESCRIPTION
Added an option to allow anchor prefix when rendering a single concept or complete dataset as discussed here -> https://github.com/metanorma/metanorma-plugin-glossarist/issues/27#issuecomment-2275553450

fixes #27 