### PR TITLE
fix: relax glossarist version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,11 @@ Encoding.default_internal = Encoding::UTF_8
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
 
+gem "metanorma-standoc"
+gem "pry"
+gem "rake", "~> 12.0"
+gem "rspec", "~> 3.0"
+
 gemspec
 
 eval_gemfile("Gemfile.devel") rescue nil

--- a/metanorma-plugin-glossarist.gemspec
+++ b/metanorma-plugin-glossarist.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "asciidoctor", "~> 2.0.0"
-  spec.add_dependency "glossarist", "~> 2.0.1"
+  spec.add_dependency "glossarist", "~> 2.0"
   spec.add_dependency "liquid", "~> 5"
 
   spec.add_development_dependency "metanorma-standoc"

--- a/metanorma-plugin-glossarist.gemspec
+++ b/metanorma-plugin-glossarist.gemspec
@@ -26,9 +26,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "asciidoctor", "~> 2.0.0"
   spec.add_dependency "glossarist", "~> 2.0"
   spec.add_dependency "liquid", "~> 5"
-
-  spec.add_development_dependency "metanorma-standoc"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
No reason to lock to "~> 2.0.1", that's overly restrictive. That means "2.0.x". I'm relaxing it to "2.x".