### PR TITLE
feat: migrate groups to domains (ConceptReference collection)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 
 # rspec failure tracking
 .rspec_status
-Gemfile.lock
 
 .rubocop-https--*
 *.log.txt
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
 
-gem "glossarist"
 gem "metanorma", github: "metanorma/metanorma", branch: "main"
 gem "metanorma-plugin-lutaml", github: "metanorma/metanorma-plugin-lutaml",
                                branch: "main"

--- a/README.adoc
+++ b/README.adoc
@@ -271,7 +271,7 @@ Multiple filters can be applied by separating them with a semicolon `;`.
 ====
 [source,adoc]
 ------
-[glossarist,dataset,filter='group=foo;sort_by=term',concepts]
+[glossarist,dataset,filter='domain=foo;sort_by=term',concepts]
 ----
 ...
 ----
@@ -287,7 +287,7 @@ which concepts are loaded into the block.
 `sort_by=<field name>`::: Sorts the dataset in ascending order of the given
 field values. The field `term` is a special case, where it sorts according to
 the `default_designation` of the term. Nested attribute paths are supported
-using dot notation (e.g., `data.id`) and bracket notation for hash/array access
+using dot notation (e.g., `data.identifier`) and bracket notation for hash/array access
 (e.g., `data.localizations['eng'].data.terms[0].designation`).
 Nested path sorts use natural ordering so that version-like identifiers
 (e.g., `3.1.1.10`) sort correctly after `3.1.1.2`. Concepts missing the
@@ -299,7 +299,7 @@ specified path are sorted last.
 default term (which is the first English designation, at `data.localizations['eng'].data.terms[0].designation`).
 
 [example]
-`sort_by=data.id` will sort concepts by their identifier.
+`sort_by=data.identifier` will sort concepts by their identifier.
 
 [example]
 `sort_by=data.localizations['eng'].data.terms[0].designation` will sort concepts
@@ -311,11 +311,18 @@ alphabetically by the English designation.
 [example]
 `lang=ara` loads all localized concepts of Arabic for all concepts.
 
-`group=<group name>`::: Loads concepts that belong to the specified group. Group is a dataset-specific
-field that can be used to categorize concepts.
+`domain=<domain name>`::: Loads concepts that belong to the specified domain.
+Domains are `ConceptReference` objects (with `concept_id` and `ref_type: "domain"`)
+that categorize concepts into subject areas.
 +
 [example]
-`group=foo` will only load concepts that have a group named `foo`.
+`domain=foo` will only load concepts that have a domain with `concept_id` "foo".
+
+`group=<group name>`::: Legacy alias for `domain`. Loads concepts that belong to
+the specified domain. Provided for backward compatibility with existing documents.
++
+[example]
+`group=foo` will only load concepts that have a domain with `concept_id` "foo".
 
 Field filters:: These filters are applied to individual fields of the concepts
 and affect which concepts are included in the block based on the values of those
@@ -724,14 +731,14 @@ System for identifying position in the real world
 ====
 
 [example]
-.Applying sorting and filtering by group
+.Applying sorting and filtering by domain
 ====
-Using the same dataset as above, but with sorting and filtering by the "terminology" group:
+Using the same dataset as above, but with sorting and filtering by the "terminology" domain:
 
 [source,asciidoc]
 ------
 === Terms and definitions
-[glossarist, /path/to/glossarist-dataset, filter='group=terminology;sort_by=term', dataset]
+[glossarist, /path/to/glossarist-dataset, filter='domain=terminology;sort_by=term', dataset]
 ----
 {%- for concept in dataset -%}
 ==== {{ concept.data.localizations['eng'].data.terms[0].designation }}
@@ -761,7 +768,7 @@ Using the same dataset, but filtering for terms related to addressing:
 [source,asciidoc]
 ------
 === Terms and definitions
-[glossarist, /path/to/glossarist-dataset, filter='group=addressing', dataset]
+[glossarist, /path/to/glossarist-dataset, filter='domain=addressing', dataset]
 ----
 {%- for concept in dataset -%}
 ==== {{ concept.data.localizations['eng'].data.terms[0].designation }}

--- a/lib/metanorma/plugin/glossarist/concept_filter.rb
+++ b/lib/metanorma/plugin/glossarist/concept_filter.rb
@@ -4,7 +4,8 @@ module Metanorma
   module Plugin
     module Glossarist
       class ConceptFilter
-        COLLECTION_FILTERS = %w[lang group sort_by].freeze
+        COLLECTION_FILTERS = %w[lang domain group sort_by].freeze
+        SORT_LAST = ["￿"].freeze
 
         def initialize(filters)
           @filters = filters || {}
@@ -13,7 +14,9 @@ module Metanorma
         def apply(collection)
           result = collection
           result = filter_by_lang(result) if @filters.key?("lang")
-          result = filter_by_group(result) if @filters.key?("group")
+          if @filters.key?("domain") || @filters.key?("group")
+            result = filter_by_domain(result)
+          end
           result = filter_by_field(result) if field_filter?
           result = sort(result) if @filters.key?("sort_by")
           result
@@ -34,9 +37,11 @@ module Metanorma
           collection.reject { |c| c.localization(lang).nil? }
         end
 
-        def filter_by_group(collection)
-          group = @filters["group"]
-          collection.select { |c| c.data.groups&.include?(group) }
+        def filter_by_domain(collection)
+          domain = @filters["domain"] || @filters["group"]
+          collection.select do |c|
+            c.data.domains&.any? { |d| d.concept_id == domain }
+          end
         end
 
         def sort(collection)
@@ -58,10 +63,9 @@ module Metanorma
           value.nil? ? SORT_LAST : natural_sort_key(value.to_s)
         end
 
-        SORT_LAST = ["￿"].freeze
-
         def natural_sort_key(str)
-          str.scan(/(\d+)|(\D+)/).map { |num, txt| num ? num.to_i : txt.downcase }
+          str.scan(/(\d+)|(\D+)/)
+            .map { |num, txt| num ? num.to_i : txt.downcase }
         end
 
         def filter_by_field(collection)

--- a/lib/metanorma/plugin/glossarist/concept_serializer.rb
+++ b/lib/metanorma/plugin/glossarist/concept_serializer.rb
@@ -9,93 +9,17 @@ module Metanorma
         end
 
         def to_h
-          { "data" => concept_data_hash }
+          data = @concept.data.to_hash
+          data["localizations"] = localizations_hash unless @concept.localizations.empty?
+          { "data" => data.compact }
         end
 
         private
 
-        def concept_data_hash
-          {
-            "id" => @concept.data.id,
-            "identifier" => @concept.data.id,
-            "localized_concepts" => @concept.data.localized_concepts,
-            "groups" => @concept.data.groups.to_a,
-            "localizations" => localizations_hash,
-            "sources" => sources_to_h(@concept.data.sources),
-          }.compact
-        end
-
         def localizations_hash
           @concept.localizations.to_h do |l10n|
-            [l10n.language_code, localized_concept_hash(l10n)]
+            [l10n.language_code, l10n.to_hash]
           end
-        end
-
-        def localized_concept_hash(l10n)
-          {
-            "data" => localized_concept_data_hash(l10n),
-            "classification" => l10n.classification,
-            "review_type" => l10n.review_type,
-          }.compact
-        end
-
-        def localized_concept_data_hash(l10n)
-          {
-            "terms" => l10n.terms.map { |t| designation_to_h(t) },
-            "definition" => definitions_to_h(l10n.definition),
-            "examples" => definitions_to_h(l10n.examples),
-            "notes" => definitions_to_h(l10n.notes),
-            "sources" => sources_to_h(l10n.sources),
-            "language_code" => l10n.language_code,
-            "entry_status" => l10n.entry_status,
-          }.compact
-        end
-
-        def designation_to_h(designation)
-          {
-            "type" => designation.type,
-            "designation" => designation.designation,
-            "normative_status" => designation.normative_status,
-            "geographical_area" => designation.geographical_area,
-          }.compact
-        end
-
-        def definitions_to_h(definitions)
-          definitions.map do |d|
-            { "content" => d.content,
-              "sources" => sources_to_h(d.sources) }.compact
-          end
-        end
-
-        def sources_to_h(sources)
-          return [] unless sources
-
-          sources.map do |source|
-            {
-              "type" => source.type,
-              "origin" => citation_to_h(source.origin),
-              "modification" => source.modification,
-            }.compact
-          end
-        end
-
-        def citation_to_h(citation)
-          return nil unless citation
-
-          hash = {}
-          hash["text"] = citation.text if citation.text && !citation.text.empty?
-          hash["ref"] = citation.text if citation.text && !citation.text.empty?
-
-          if citation.locality
-            hash["locality"] = {
-              "type" => citation.locality.type,
-              "reference_from" => citation.locality.reference_from,
-            }
-            hash["clause"] = citation.locality.reference_from
-          end
-
-          hash["link"] = citation.link if citation.link
-          hash
         end
       end
     end

--- a/spec/metanorma/plugin/glossarist/concept_filter_spec.rb
+++ b/spec/metanorma/plugin/glossarist/concept_filter_spec.rb
@@ -32,14 +32,21 @@ RSpec.describe Metanorma::Plugin::Glossarist::ConceptFilter do
       end
     end
 
-    describe "group filter" do
-      it "filters by group" do
-        filter = described_class.new({ "group" => "foo" })
+    describe "domain filter" do
+      it "filters by domain" do
+        filter = described_class.new({ "domain" => "foo" })
         result = filter.apply(all_concepts)
         designations = result.map(&:default_designation)
         expect(designations).to include("entity")
         expect(designations).to include("material entity")
         expect(designations).not_to include("biological entity")
+      end
+
+      it "backward-compatible: 'group' alias still works" do
+        filter = described_class.new({ "group" => "foo" })
+        result = filter.apply(all_concepts)
+        designations = result.map(&:default_designation)
+        expect(designations).to include("entity")
       end
     end
 
@@ -58,8 +65,8 @@ RSpec.describe Metanorma::Plugin::Glossarist::ConceptFilter do
         expect(designations).to eq(designations.sort_by(&:downcase))
       end
 
-      it "sorts by simple nested path (data.id)" do
-        filter = described_class.new({ "sort_by" => "data.id" })
+      it "sorts by simple nested path (data.identifier)" do
+        filter = described_class.new({ "sort_by" => "data.identifier" })
         result = filter.apply(all_concepts)
         ids = result.map { |c| c.data.id }
         expect(ids).to eq(["3.1.1.1", "3.1.1.3", "3.1.1.5", "3.1.1.6"])
@@ -113,22 +120,22 @@ RSpec.describe Metanorma::Plugin::Glossarist::ConceptFilter do
         expect(designations.length).to eq(all_concepts.length)
       end
 
-      it "applies group and sort_by together" do
-        filter = described_class.new({ "group" => "foo", "sort_by" => "term" })
+      it "applies domain and sort_by together" do
+        filter = described_class.new({ "domain" => "foo", "sort_by" => "term" })
         result = filter.apply(all_concepts)
         designations = result.map(&:default_designation)
         expect(designations).to eq(["entity", "material entity"])
       end
 
-      it "applies group and nested sort_by together" do
-        filter = described_class.new({ "group" => "bar", "sort_by" => "data.id" })
+      it "applies domain and nested sort_by together" do
+        filter = described_class.new({ "domain" => "bar", "sort_by" => "data.identifier" })
         result = filter.apply(all_concepts)
         ids = result.map { |c| c.data.id }
         expect(ids).to eq(["3.1.1.5", "3.1.1.6"])
       end
 
       it "applies lang and nested sort_by together" do
-        filter = described_class.new({ "lang" => "deu", "sort_by" => "data.id" })
+        filter = described_class.new({ "lang" => "deu", "sort_by" => "data.identifier" })
         result = filter.apply(all_concepts)
         ids = result.map { |c| c.data.id }
         expect(ids).to eq(["3.1.1.6"])

--- a/spec/metanorma/plugin/glossarist/concept_serializer_spec.rb
+++ b/spec/metanorma/plugin/glossarist/concept_serializer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::ConceptSerializer do
     end
 
     it "includes concept id" do
-      expect(subject["data"]["id"]).to eq("3.1.1.1")
+      expect(subject["data"]["identifier"]).to eq("3.1.1.1")
     end
 
     it "includes localizations" do
@@ -52,11 +52,13 @@ RSpec.describe Metanorma::Plugin::Glossarist::ConceptSerializer do
       expect(eng["data"]["sources"]).to be_a(Array)
     end
 
-    it "includes groups when present" do
-      entity_with_group = collection.find { |c| c.data.groups&.include?("foo") }
-      if entity_with_group
-        hash = described_class.new(entity_with_group).to_h
-        expect(hash["data"]["groups"]).to include("foo")
+    it "includes domains when present" do
+      entity_with_domain = collection.find { |c| c.data.domains&.any? { |d| d.concept_id == "foo" } }
+      if entity_with_domain
+        hash = described_class.new(entity_with_domain).to_h
+        expect(hash["data"]["domains"]).to include(
+          include("concept_id" => "foo", "ref_type" => "domain"),
+        )
       end
     end
   end

--- a/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
@@ -229,16 +229,17 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
             end
           end
 
-          describe "filter='sort_by=data.id' (nested attribute sorting)" do
+          describe "filter='sort_by=data.identifier' " \
+                   "(nested attribute sorting)" do
             let(:reader) do
               Asciidoctor::Reader.new <<~TEMPLATE
                 some text before glossarist block
 
                 === Section 1
-                [glossarist,./spec/fixtures/dataset-glossarist-v2,filter='sort_by=data.id',concepts]
+                [glossarist,./spec/fixtures/dataset-glossarist-v2,filter='sort_by=data.identifier',concepts]
                 ----
                 {% for concept in concepts %}
-                ==== {{ concept.data.id }}
+                ==== {{ concept.data.identifier }}
                 {% endfor %}
                 ----
 


### PR DESCRIPTION
Migrates from legacy `groups` string array to `domains` (ConceptReference collection) to align with glossarist-ruby data model.

### Changes
- **ConceptFilter**: `filter_by_group` → `filter_by_domain` with backward-compat `group` alias
- **ConceptSerializer**: rewritten to use lutaml-model `to_hash` for model-driven serialization
- **Specs**: updated from `groups` to `domains`, `data.id` to `data.identifier`
- **Fixtures**: kept legacy `groups:` key for backward compat testing
- **README**: updated filter docs for `domain=` and `data.identifier`

### Test results
- 72 tests passing

Depends on: glossarist/glossarist-ruby#163