### PR TITLE
chore: require glossarist ~> 2.6, >= 2.6.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,4 @@ gem "rubocop-performance"
 gem "rubocop-rake"
 gem "rubocop-rspec"
 
-# TODO: remove once glossarist 2.7.0 is released with Citation#label
-gem "glossarist", github: "glossarist/glossarist-ruby", branch: "main"
-
 gemspec

--- a/metanorma-plugin-glossarist.gemspec
+++ b/metanorma-plugin-glossarist.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "asciidoctor"
-  spec.add_dependency "glossarist", "~> 2.6"
+  spec.add_dependency "glossarist", "~> 2.6", ">= 2.6.7"
   spec.add_dependency "liquid"
   spec.add_dependency "metanorma-utils"
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
Updates glossarist gemspec dependency to `"~> 2.6", ">= 2.6.7"` to ensure Citation::Ref structured hash support (source + id + version).

Depends on glossarist 2.6.7+ (Citation::Ref, ConceptRef, label method).