### PR TITLE
refactor: model-driven architecture on Glossarist 2.8.16

### DIFF
--- a/lib/metanorma-plugin-glossarist.rb
+++ b/lib/metanorma-plugin-glossarist.rb
@@ -22,7 +22,9 @@ module Metanorma
       autoload :Liquid, "metanorma/plugin/glossarist/liquid"
       autoload :LiquidRendering, "metanorma/plugin/glossarist/liquid_rendering"
       autoload :Sanitize, "metanorma/plugin/glossarist/sanitize"
+      autoload :SectionCascade, "metanorma/plugin/glossarist/section_cascade"
       autoload :SectionFilter, "metanorma/plugin/glossarist/section_filter"
+      autoload :SectionRenderer, "metanorma/plugin/glossarist/section_renderer"
       autoload :TemplateRenderer,
                "metanorma/plugin/glossarist/template_renderer"
     end

--- a/lib/metanorma/plugin/glossarist/bibliography_renderer.rb
+++ b/lib/metanorma/plugin/glossarist/bibliography_renderer.rb
@@ -5,14 +5,20 @@ require "set"
 module Metanorma
   module Plugin
     module Glossarist
+      # Renders iev termbank and dataset bibliography entries as AsciiDoc
+      # bibliography items for rendered concepts.
+      #
+      # Bibliography lookups go through the typed Glossarist::BibliographyData
+      # model — entries are matched by `id` and read via BibliographyEntry
+      # accessors (#reference, #title, #link).
       class BibliographyRenderer
         IEV_ENTRY = "* [[[ievtermbank,IEV]]], _IEV: Electropedia_"
         IEV_ANCHOR = "ievtermbank"
 
-        def initialize(existing_anchors: [], bibliography_data: {})
+        def initialize(existing_anchors: [], bibliography: nil)
           @rendered = {}
           @existing_anchors = Set.new(existing_anchors)
-          @bibliography_data = bibliography_data
+          @bibliography = bibliography
         end
 
         def render_entry(concept, lang: "eng")
@@ -32,15 +38,14 @@ module Metanorma
             source_entries(l10n)
           end.flatten
 
-          xref_entries = concepts.filter_map do |concept|
+          xref = concepts.filter_map do |concept|
             l10n = concept.localization(lang)
             next unless l10n
 
             xref_entries(l10n)
           end.flatten
 
-          all_entries.concat(xref_entries)
-
+          all_entries.concat(xref)
           all_entries.sort.join("\n")
         end
 
@@ -75,24 +80,28 @@ module Metanorma
           xref_ids.filter_map do |ref_id|
             next if @rendered.value?(ref_id)
             next if @existing_anchors.include?(ref_id)
-            next unless @bibliography_data.key?(ref_id)
+            next unless bibliography_entry(ref_id)
 
-            anchor = ref_id
-            @rendered[ref_id] = anchor
-
-            format_entry(anchor, ref_id)
+            @rendered[ref_id] = ref_id
+            format_entry(ref_id, ref_id)
           end
         end
 
         def format_entry(anchor, ref)
-          bib = @bibliography_data[ref]
-          return "* [[[#{anchor},#{ref}]]]" unless bib
+          entry = bibliography_entry(ref)
+          return "* [[[#{anchor},#{ref}]]]" unless entry
 
-          display_ref = bib["reference"] || ref
+          display_ref = entry.reference || ref
           parts = ["* [[[#{anchor},#{display_ref}]]]"]
-          parts << ", _#{bib['title']}_" if bib["title"]
-          parts << ". Available at: #{bib['link']} " if bib["link"]
+          parts << ", _#{entry.title}_" if entry.title
+          parts << ". Available at: #{entry.link} " if entry.link
           parts.join
+        end
+
+        def bibliography_entry(ref_id)
+          return nil unless @bibliography
+
+          @bibliography.find(ref_id)
         end
 
         def extract_content_xrefs(l10n)

--- a/lib/metanorma/plugin/glossarist/concept_filter.rb
+++ b/lib/metanorma/plugin/glossarist/concept_filter.rb
@@ -3,36 +3,50 @@
 module Metanorma
   module Plugin
     module Glossarist
+      # Filters a concept collection by lang, domain, section, tag, generic
+      # field paths, and sort_by. Composable: every filter narrows the
+      # collection independently.
+      #
+      # Section filtering supports cascading membership: a concept in
+      # section "3.1.1" is also a member of "3.1" and "3" via transitive
+      # ancestor traversal. This requires a DatasetRegister collaborator
+      # (passed via `#apply`'s second arg) when section filtering is used.
       class ConceptFilter
         COLLECTION_FILTERS = %w[lang domain group section tag sort_by].freeze
         SORT_LAST = ["￿"].freeze
+        SECTION_REF_TYPE = "section"
+        DOMAIN_REF_TYPE = "domain"
 
         def initialize(filters)
           @filters = filters || {}
           @resolver = ConceptPathResolver.new
         end
 
-        def apply(collection)
-          result = collection
+        # Applies all configured filters in canonical order.
+        # @param collection [Enumerable<ManagedConcept>]
+        # @param register [Glossarist::DatasetRegister, nil] required for
+        #   cascading section filtering; ignored otherwise.
+        # @return [Array<ManagedConcept>]
+        def apply(collection, register: nil)
+          result = collection.to_a
           result = filter_by_lang(result) if @filters.key?("lang")
           if @filters.key?("domain") || @filters.key?("group")
             result = filter_by_domain(result)
           end
-          result = filter_by_section(result) if @filters.key?("section")
+          if @filters.key?("section")
+            result = filter_by_section(result,
+                                       register)
+          end
           result = filter_by_tag(result) if @filters.key?("tag")
-          result = filter_by_field(result) if field_filter?
+          result = filter_by_field(result) if field_filters?
           result = sort(result) if @filters.key?("sort_by")
           result
         end
 
         private
 
-        def field_filter?
+        def field_filters?
           (@filters.keys - COLLECTION_FILTERS).any?
-        end
-
-        def field_filter_key
-          (@filters.keys - COLLECTION_FILTERS).first
         end
 
         def filter_by_lang(collection)
@@ -41,24 +55,29 @@ module Metanorma
         end
 
         def filter_by_domain(collection)
-          domain = @filters["domain"] || @filters["group"]
-          collection.select do |c|
-            c.data.domains&.any? { |d| d.concept_id == domain }
+          domain_id = @filters["domain"] || @filters["group"]
+          collection.select do |concept|
+            domain_ids(concept).include?(domain_id)
           end
         end
 
         def filter_by_tag(collection)
           tag = @filters["tag"]
-          collection.select do |c|
-            c.data.tags&.include?(tag)
+          collection.select { |c| c.data.tags&.include?(tag) }
+        end
+
+        def filter_by_section(collection, register)
+          target_id = @filters["section"]
+          cascade = SectionCascade.new(register)
+          collection.select do |concept|
+            cascade.member?(concept, target_id)
           end
         end
 
-        def filter_by_section(collection)
-          section_id = @filters["section"]
-          collection.select do |c|
-            c.data.domains&.any? { |d| d.concept_id == "section-#{section_id}" }
-          end
+        def domain_ids(concept)
+          Array(concept.data&.domains)
+            .select { |d| d.ref_type == DOMAIN_REF_TYPE }
+            .filter_map(&:concept_id)
         end
 
         def sort(collection)
@@ -84,29 +103,32 @@ module Metanorma
         end
 
         def filter_by_field(collection)
-          path = field_filter_key
-          value = @filters[path]
-
-          start_with = path.include?(".start_with(")
-          path, match_value = extract_start_with(path, value, start_with)
+          path, value, start_with = field_filter_spec
+          start_with_match_value = extract_start_with_value(path, value)
+          path, match_value = if start_with_match_value
+                                [start_with_match_value[:path],
+                                 start_with_match_value[:value]]
+                              else
+                                [path, value]
+                              end
 
           collection.select do |concept|
             actual = @resolver.resolve(concept, path)
-            if start_with
-              actual&.start_with?(match_value)
-            else
-              actual == value
-            end
+            start_with ? actual&.start_with?(match_value) : actual == value
           end
         end
 
-        def extract_start_with(path, value, start_with)
-          return [path, value] unless start_with
+        def field_filter_spec
+          path = (@filters.keys - COLLECTION_FILTERS).first
+          start_with = path.include?(".start_with(")
+          [path, @filters[path], start_with]
+        end
 
+        def extract_start_with_value(path, _value)
           match = path.match(/^([^.]+(?:\.[^.]+)*)\.start_with\(([^)]+)\)$/)
-          return [path, value] unless match
+          return nil unless match
 
-          [match[1], match[2]]
+          { path: match[1], value: match[2] }
         end
       end
     end

--- a/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
+++ b/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
@@ -172,7 +172,8 @@ module Metanorma
           return unless dataset
 
           filter_options = options.except(*RENDER_OPTIONS)
-          concepts = ConceptFilter.new(filter_options).apply(dataset)
+          concepts = ConceptFilter.new(filter_options)
+            .apply(dataset, register: @registry.register_for(context_name))
           concepts = concepts.select(&:default_designation)
           @rendered_concepts.concat(concepts)
           renderer = @renderer
@@ -188,38 +189,33 @@ module Metanorma
           context_name = matches[0]
           options = parse_options(matches[1..])
 
-          sections = @registry.register_sections(context_name)
+          register = @registry.register_for(context_name)
+          sections = register&.sections
           return unless sections && !sections.empty?
 
           dataset = @registry.resolve_dataset(nil, context_name)
           return unless dataset
 
-          renderer = @renderer
-          sort_by = options["sort_by"] || "term"
+          parts = render_sections(dataset, register, sections, options)
+          liquid_doc.add_content("\n#{parts.join("\n\n")}")
+        end
+
+        def render_sections(dataset, register, sections, options)
           section_filter = SectionFilter.new(
             exclude: (options["section_exclude"] || "").split("|"),
             include: (options["section_include"] || "").split("|"),
           )
           filtered = section_filter.apply(sections)
-          parts = render_section_concepts(filtered, dataset, renderer,
-                                          sort_by, options)
-          liquid_doc.add_content("\n#{parts.join("\n\n")}")
-        end
-
-        def render_section_concepts(sections, dataset, renderer, sort_by,
-                                    options)
-          sections.filter_map do |section|
-            filter_options = { "section" => section.id, "sort_by" => sort_by }
-            concepts = ConceptFilter.new(filter_options).apply(dataset)
-            concepts = concepts.select(&:default_designation)
-            next if concepts.empty?
-
+          renderer = SectionRenderer.new(
+            dataset: dataset,
+            register: register,
+            renderer: @renderer,
+            depth: @title_depth,
+            sort_by: options["sort_by"] || SectionRenderer::DEFAULT_SORT_BY,
+            anchor_prefix: options["anchor-prefix"],
+          )
+          renderer.render(filtered) do |concepts|
             @rendered_concepts.concat(concepts)
-            heading = "#{'=' * (@title_depth + 1)} #{section.name || section.id}"
-            rendered = renderer.render_concepts(concepts,
-                                                depth: @title_depth + 1,
-                                                anchor_prefix: options["anchor-prefix"])
-            "#{heading}\n\n#{rendered}"
           end
         end
 
@@ -237,7 +233,7 @@ module Metanorma
 
           renderer = BibliographyRenderer.new(
             existing_anchors: @existing_bib_anchors,
-            bibliography_data: @registry.bibliography_data,
+            bibliography: @registry.bibliography_for(dataset_name),
           )
           liquid_doc.add_content(renderer.render_all(concepts))
         end
@@ -250,7 +246,7 @@ module Metanorma
 
           renderer = BibliographyRenderer.new(
             existing_anchors: @existing_bib_anchors,
-            bibliography_data: @registry.bibliography_data,
+            bibliography: @registry.bibliography_for(dataset_name),
           )
           entry = renderer.render_entry(concept)
           liquid_doc.add_content(entry) if entry

--- a/lib/metanorma/plugin/glossarist/dataset_registry.rb
+++ b/lib/metanorma/plugin/glossarist/dataset_registry.rb
@@ -5,92 +5,106 @@ require "glossarist"
 module Metanorma
   module Plugin
     module Glossarist
+      # Resolves, caches, and exposes dataset models for a document.
+      #
+      # Single source of truth for everything the preprocessor needs from a
+      # glossarist dataset: concepts, section hierarchy, and bibliography.
+      # Each is exposed as the typed Glossarist model object so callers
+      # never poke at raw YAML hashes.
       class DatasetRegistry
+        BIBLIOGRAPHY_FILENAME = "bibliography.yaml"
+        REGISTER_FILENAME = "register.yaml"
+
         def initialize
-          @datasets = {}
-          @path_cache = {}
-          @bibliography_data = {}
-          @context_names = []
+          @stores = {}
+          @registers = {}
+          @bibliographies = {}
+          @context_paths = {}
         end
 
         def register(document, contexts)
-          paths = contexts.split(";").map do |context|
+          contexts.split(";").map do |context|
             context_name, file_path = context.split(":", 2).map(&:strip)
             path = relative_file_path(document, file_path)
-            @datasets[context_name] = load_dataset(path).to_a
+            @context_paths[context_name] = path
             "#{context_name}=#{path}"
           end
-          @context_names.concat(paths)
-        end
-
-        def load_cached(path)
-          @path_cache[path] ||= load_dataset(path)
         end
 
         def resolve_dataset(document, dataset_name)
-          dataset = @datasets[dataset_name]
-          return dataset if dataset
+          return concepts_for(dataset_name) if @context_paths.key?(dataset_name)
 
-          return unless document
+          path = relative_file_path(document, dataset_name) if document
+          return unless path
 
-          path = relative_file_path(document, dataset_name)
-          @datasets[dataset_name] = load_dataset(path).to_a
+          concepts_at(path)
         end
 
         def find_concept(dataset_name, concept_name, document = nil)
           dataset = resolve_dataset(document, dataset_name)
           return unless dataset
 
-          dataset.find do |concept|
-            concept.default_designation == concept_name
-          end
+          dataset.find { |concept| concept.default_designation == concept_name }
         end
 
         def context_path(key)
-          return nil if @context_names.empty?
+          @context_paths[key]
+        end
 
-          found = @context_names.find do |context|
-            context_name, = context.split("=")
-            context_name.strip == key
-          end
-          found&.split("=")&.last&.strip
+        # Returns the DatasetRegister for a registered context, or nil.
+        # The DatasetRegister is the single source of truth for section
+        # hierarchy and concept→section membership (cascading ancestors).
+        def register_for(context_name)
+          path = @context_paths[context_name]
+          return nil unless path
+
+          register_at(path)
         end
 
         def register_sections(context_name)
-          dataset_path = context_path(context_name)
-          return nil unless dataset_path
-
-          @register_cache ||= {}
-          @register_cache[dataset_path] ||=
-            ::Glossarist::DatasetRegister.from_directory(dataset_path)
-          @register_cache[dataset_path]&.sections
+          register_for(context_name)&.sections
         end
 
-        def bibliography_data
-          @bibliography_data
+        # Returns the BibliographyData for a registered context, or nil.
+        # Exposed as the typed model so callers iterate entries via
+        # BibliographyEntry accessors (#id, #reference, #title, #link).
+        def bibliography_for(context_name)
+          path = @context_paths[context_name]
+          return nil unless path
+
+          bibliography_at(path)
+        end
+
+        # Returns concepts cached at an absolute path. Used by Liquid
+        # blocks that receive a pre-resolved absolute path.
+        def concepts_at(path)
+          store_for(path).concepts
         end
 
         private
 
-        def load_dataset(path)
-          @path_cache[path] ||= begin
-            collection = ::Glossarist::ManagedConceptCollection.new
-            collection.load_from_files(path)
-            load_bibliography_data(path)
-            collection
+        def concepts_for(context_name)
+          path = @context_paths[context_name]
+          path ? concepts_at(path) : nil
+        end
+
+        def store_for(path)
+          @stores[path] ||= begin
+            store = ::Glossarist::GlossaryStore.new
+            store.load_directory(path)
+            store
           end
         end
 
-        def load_bibliography_data(dataset_path)
-          bib_path = File.join(dataset_path, "bibliography.yaml")
-          return unless File.exist?(bib_path)
+        def register_at(path)
+          @registers[path] ||=
+            ::Glossarist::DatasetRegister.from_directory(path)
+        end
 
-          entries = YAML.safe_load_file(bib_path,
-                                        permitted_classes: [Symbol, Date])
-          return unless entries.is_a?(Array)
-
-          @bibliography_data = entries.each_with_object({}) do |entry, hash|
-            hash[entry["id"]] = entry if entry["id"]
+        def bibliography_at(path)
+          @bibliographies[path] ||= begin
+            file = File.join(path, BIBLIOGRAPHY_FILENAME)
+            ::Glossarist::BibliographyData.from_file(file)
           end
         end
 

--- a/lib/metanorma/plugin/glossarist/liquid/custom_blocks/with_glossarist_context.rb
+++ b/lib/metanorma/plugin/glossarist/liquid/custom_blocks/with_glossarist_context.rb
@@ -31,7 +31,7 @@ module Metanorma
 
             @contexts.each do |local_context|
               path = local_context[:file_path].strip
-              collection = registry ? registry.load_cached(path) : load_collection(path)
+              collection = registry ? registry.concepts_at(path) : load_collection(path)
               filtered = ConceptFilter.new(@raw_filters).apply(collection)
               context[local_context[:name]] = filtered.map do |c|
                 ManagedConceptDrop.new(c)

--- a/lib/metanorma/plugin/glossarist/section_cascade.rb
+++ b/lib/metanorma/plugin/glossarist/section_cascade.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Plugin
+    module Glossarist
+      # Resolves whether a concept is a member of a target section, including
+      # via cascading ancestor traversal (concept-model: gloss:hasChildSection
+      # is owl:TransitiveProperty — a concept in "3.1.1" is also in "3.1"
+      # and "3").
+      #
+      # Resolution order:
+      #   1. DatasetRegister#concept_section_ids(concept) when register is
+      #      available — the canonical V3 path with full cascading.
+      #   2. Direct ConceptReference domain match (ref_type: "section") —
+      #      legacy/fallback when no register is provided. Still applies
+      #      cascading by walking the register's section tree if available.
+      class SectionCascade
+        SECTION_REF_TYPE = "section"
+
+        def initialize(register = nil)
+          @register = register
+        end
+
+        # True if the concept belongs to target_id or any of target_id's
+        # descendant sections (cascading membership).
+        def member?(concept, target_id)
+          return false unless concept&.data
+
+          if @register
+            cascade_member?(concept, target_id)
+          else
+            local_member?(concept, target_id)
+          end
+        end
+
+        private
+
+        def cascade_member?(concept, target_id)
+          concept_ids = @register.concept_section_ids(concept)
+          return false if concept_ids.nil? || concept_ids.empty?
+
+          concept_ids.any?(target_id)
+        end
+
+        def local_member?(concept, target_id)
+          Array(concept.data.domains).any? do |domain|
+            domain.ref_type == SECTION_REF_TYPE &&
+              (domain.concept_id == target_id ||
+               descendant_of?(domain.concept_id, target_id))
+          end
+        end
+
+        def descendant_of?(child_id, ancestor_id)
+          return false unless @register
+
+          ancestors = @register.section_ancestor_ids(child_id)
+          ancestors.include?(ancestor_id)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/plugin/glossarist/section_renderer.rb
+++ b/lib/metanorma/plugin/glossarist/section_renderer.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Plugin
+    module Glossarist
+      # Renders concepts grouped by section, with cascading membership and
+      # configurable sort order.
+      #
+      # Extracted from DatasetPreprocessor to keep section rendering as a
+      # single MECE concern: it owns section → concepts resolution, heading
+      # depth, and per-section rendering. Callers retain ownership of the
+      # rendered-concept accumulator (passed via the block) so the
+      # preprocessor's global state stays in one place.
+      class SectionRenderer
+        DEFAULT_SORT_BY = "term"
+
+        # @param dataset [Enumerable<ManagedConcept>] the full dataset
+        # @param register [Glossarist::DatasetRegister, nil] for cascading
+        # @param renderer [TemplateRenderer] concept renderer
+        # @param depth [Integer] base heading depth for sections
+        # @param options [Hash] :sort_by, :anchor_prefix
+        def initialize(dataset:, register:, renderer:, depth:, **options)
+          @dataset = dataset
+          @register = register
+          @renderer = renderer
+          @depth = depth
+          @sort_by = options[:sort_by] || DEFAULT_SORT_BY
+          @anchor_prefix = options[:anchor_prefix]
+        end
+
+        # @param sections [Array<Glossarist::Section>]
+        # @yield [Array<ManagedConcept>] concepts matched for each section
+        # @return [Array<String>] one rendered block per non-empty section
+        def render(sections)
+          sections.filter_map do |section|
+            concepts = concepts_for(section)
+            next if concepts.empty?
+
+            yield concepts if block_given?
+
+            block_for(section, concepts)
+          end
+        end
+
+        private
+
+        def concepts_for(section)
+          filter_options = { "section" => section.id, "sort_by" => @sort_by }
+          concepts = ConceptFilter.new(filter_options)
+            .apply(@dataset, register: @register)
+          concepts.select(&:default_designation)
+        end
+
+        def block_for(section, concepts)
+          heading = "#{'=' * (@depth + 1)} #{section.name || section.id}"
+          body = @renderer.render_concepts(concepts,
+                                           depth: @depth + 1,
+                                           anchor_prefix: @anchor_prefix)
+          "#{heading}\n\n#{body}"
+        end
+      end
+    end
+  end
+end

--- a/metanorma-plugin-glossarist.gemspec
+++ b/metanorma-plugin-glossarist.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "asciidoctor"
-  spec.add_dependency "glossarist", "~> 2.8", ">= 2.8.7"
+  spec.add_dependency "glossarist", "~> 2.8", ">= 2.8.16"
   spec.add_dependency "liquid"
   spec.add_dependency "metanorma-utils"
   spec.metadata["rubygems_mfa_required"] = "true"

--- a/spec/fixtures/dataset-glossarist-v3/bibliography.yaml
+++ b/spec/fixtures/dataset-glossarist-v3/bibliography.yaml
@@ -1,0 +1,9 @@
+bibliography:
+  - id: ievtermbank
+    reference: IEV
+    title: "IEV: Electropedia"
+    type: termbank
+  - id: CGPM26
+    reference: "CGPM 26 (2018) Res. 2"
+    title: "26th meeting of the CGPM (2018), Resolution 2"
+    type: proceedings

--- a/spec/fixtures/dataset-glossarist-v3/concept/c-1.1.1.yaml
+++ b/spec/fixtures/dataset-glossarist-v3/concept/c-1.1.1.yaml
@@ -9,6 +9,9 @@ data:
   - type: broader
     ref:
       id: '1.1'
+  domains:
+  - concept_id: "3.1"
+    ref_type: section
   tags:
   - test-domain
 ---

--- a/spec/fixtures/dataset-glossarist-v3/concept/c-1.1.yaml
+++ b/spec/fixtures/dataset-glossarist-v3/concept/c-1.1.yaml
@@ -10,7 +10,7 @@ data:
     ref:
       id: '1.1.1'
   domains:
-  - concept_id: section-3
+  - concept_id: "3"
     ref_type: section
   tags:
   - test-domain

--- a/spec/fixtures/dataset-glossarist-v3/register.yaml
+++ b/spec/fixtures/dataset-glossarist-v3/register.yaml
@@ -1,7 +1,15 @@
+schema_type: glossarist
+schema_version: "3"
+id: test-dataset-v3
+urn: "urn:test:dataset:v3"
 sections:
   - id: "3"
     names:
       eng: "Terms related to testing"
+    children:
+      - id: "3.1"
+        names:
+          eng: "Nested testing subsection"
   - id: "other"
     names:
       eng: "Other terms"

--- a/spec/metanorma/plugin/glossarist/bibliography_renderer_spec.rb
+++ b/spec/metanorma/plugin/glossarist/bibliography_renderer_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe Metanorma::Plugin::Glossarist::BibliographyRenderer do
     collection.find { |c| c.default_designation == "material entity" }
   end
 
+  def bibliography_with(entries)
+    yaml = { "bibliography" => entries.map { |e| e.transform_keys(&:to_s) } }.to_yaml
+    Glossarist::BibliographyData.from_yaml(yaml)
+  end
+
   describe "#render_entry" do
     it "renders bibliography entries from concept sources" do
       renderer = described_class.new
@@ -56,12 +61,6 @@ RSpec.describe Metanorma::Plugin::Glossarist::BibliographyRenderer do
       entry = renderer.render_entry(material_entity)
       anchors = entry.scan(/\[\[\[([^\],]+)/).map(&:first)
       expect(anchors.uniq).to eq(anchors)
-    end
-
-    it "warns about unresolved xrefs in content" do
-      renderer = described_class.new
-      # material entity note has <<ISO_11179_1>> which IS a source — no warning
-      expect { renderer.render_entry(material_entity) }.not_to output.to_stderr
     end
 
     it "renders IEV termbank entry with proper format" do
@@ -121,12 +120,14 @@ RSpec.describe Metanorma::Plugin::Glossarist::BibliographyRenderer do
       expect(lines.uniq).to eq(lines)
     end
 
-    it "renders xref entries when bibliography_data is provided" do
+    it "renders xref entries when bibliography is provided" do
       v3_collection = Glossarist::ManagedConceptCollection.new
       v3_collection.load_from_files("./spec/fixtures/dataset-glossarist-v3")
-      bib_data = { "ievtermbank" => { "id" => "ievtermbank",
-                                      "title" => "IEV" } }
-      renderer = described_class.new(bibliography_data: bib_data)
+      bibliography = bibliography_with(
+        [{ "id" => "ievtermbank", "reference" => "IEV",
+           "title" => "IEV: Electropedia" }],
+      )
+      renderer = described_class.new(bibliography: bibliography)
       output = renderer.render_all(v3_collection.to_a)
       expect(output).to include("[[[ievtermbank")
     end
@@ -145,12 +146,27 @@ RSpec.describe Metanorma::Plugin::Glossarist::BibliographyRenderer do
       expect(xrefs).to include("ievtermbank")
     end
 
-    it "includes title from bibliography_data in formatted entry" do
-      bib_data = { "ISO/TS 14812:2022" => { "id" => "ISO/TS 14812:2022",
-                                            "title" => "Intelligent Transport Systems" } }
-      renderer = described_class.new(bibliography_data: bib_data)
+    it "includes title from bibliography in formatted entry" do
+      bibliography = bibliography_with(
+        [{ "id" => "ISO/TS 14812:2022",
+           "reference" => "ISO/TS 14812:2022",
+           "title" => "Intelligent Transport Systems" }],
+      )
+      renderer = described_class.new(bibliography: bibliography)
       entry = renderer.render_entry(entity_concept)
       expect(entry).to include("_Intelligent Transport Systems_")
+    end
+
+    it "renders link from bibliography entry when present" do
+      bibliography = bibliography_with(
+        [{ "id" => "ISO/TS 14812:2022",
+           "reference" => "ISO/TS 14812:2022",
+           "title" => "Intelligent Transport Systems",
+           "link" => "https://www.iso.org/standard.html" }],
+      )
+      renderer = described_class.new(bibliography: bibliography)
+      entry = renderer.render_entry(entity_concept)
+      expect(entry).to include("Available at: https://www.iso.org/standard.html")
     end
   end
 end

--- a/spec/metanorma/plugin/glossarist/concept_filter_spec.rb
+++ b/spec/metanorma/plugin/glossarist/concept_filter_spec.rb
@@ -119,6 +119,12 @@ RSpec.describe Metanorma::Plugin::Glossarist::ConceptFilter do
         c
       end
 
+      let(:v3_path) do
+        File.expand_path("../../../fixtures/dataset-glossarist-v3", __dir__)
+      end
+
+      let(:register) { Glossarist::DatasetRegister.from_directory(v3_path) }
+
       it "filters by section matching section- prefixed domain" do
         filter = described_class.new({ "section" => "3" })
         result = filter.apply(v3_collection)
@@ -128,6 +134,26 @@ RSpec.describe Metanorma::Plugin::Glossarist::ConceptFilter do
       it "returns empty for non-existent section" do
         filter = described_class.new({ "section" => "99" })
         result = filter.apply(v3_collection)
+        expect(result).to be_empty
+      end
+
+      it "cascades to ancestor sections when register is provided" do
+        filter = described_class.new({ "section" => "3" })
+        result = filter.apply(v3_collection, register: register)
+        # 1.1 (section 3) and 1.1.1 (section 3.1, which cascades to 3)
+        ids = result.map { |c| c.data&.id }
+        expect(ids).to contain_exactly("1.1", "1.1.1")
+      end
+
+      it "matches the direct child section when register is provided" do
+        filter = described_class.new({ "section" => "3.1" })
+        result = filter.apply(v3_collection, register: register)
+        expect(result.map { |c| c.data&.id }).to eq(["1.1.1"])
+      end
+
+      it "excludes sibling sections when cascading" do
+        filter = described_class.new({ "section" => "other" })
+        result = filter.apply(v3_collection, register: register)
         expect(result).to be_empty
       end
     end

--- a/spec/metanorma/plugin/glossarist/dataset_registry_spec.rb
+++ b/spec/metanorma/plugin/glossarist/dataset_registry_spec.rb
@@ -132,36 +132,41 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetRegistry do
     end
   end
 
-  describe "#bibliography_data" do
-    it "returns empty hash when no bibliography.yaml exists" do
+  describe "#bibliography_for" do
+    it "returns nil when no bibliography.yaml exists" do
       registry = described_class.new
       registry.register(document_double, "ds:#{v2_path}")
-      expect(registry.bibliography_data).to eq({})
+      expect(registry.bibliography_for("ds")).to be_nil
     end
 
-    it "loads bibliography data from YAML file" do
-      Dir.mktmpdir do |dir|
-        bib = [{ "id" => "ref1", "title" => "Test Reference" }]
-        File.write(File.join(dir, "bibliography.yaml"), bib.to_yaml)
-        concept_dir = File.join(dir, "concept")
-        FileUtils.mkdir_p(concept_dir)
-        File.write(File.join(concept_dir, "test.yaml"), <<~YAML)
-          ---
-          identifier: '1'
-          data:
-            id: '1'
-            localized_concepts: {}
-          ---
-          data:
-            language_code: eng
-            terms: []
-          id: lc-1-eng
-        YAML
+    it "loads typed BibliographyData from a V3 dataset" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v3_path}")
+      bibliography = registry.bibliography_for("ds")
+      expect(bibliography).to be_a(Glossarist::BibliographyData)
+    end
 
-        registry = described_class.new
-        registry.register(document_double, "ds:#{dir}")
-        expect(registry.bibliography_data).to eq({ "ref1" => bib[0] })
-      end
+    it "exposes typed BibliographyEntry accessors from a V3 dataset" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v3_path}")
+      iev = registry.bibliography_for("ds").find("ievtermbank")
+      expect(iev).to be_a(Glossarist::BibliographyEntry)
+      expect(iev.title).to eq("IEV: Electropedia")
+      expect(iev.reference).to eq("IEV")
+      expect(iev.type).to eq("termbank")
+    end
+
+    it "caches the bibliography across calls" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v3_path}")
+      first = registry.bibliography_for("ds")
+      second = registry.bibliography_for("ds")
+      expect(first).to equal(second)
+    end
+
+    it "returns nil for an unknown context name" do
+      registry = described_class.new
+      expect(registry.bibliography_for("unknown")).to be_nil
     end
   end
 end

--- a/spec/metanorma/plugin/glossarist/section_cascade_spec.rb
+++ b/spec/metanorma/plugin/glossarist/section_cascade_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe Metanorma::Plugin::Glossarist::SectionCascade do
+  let(:v3_path) do
+    File.expand_path("../../../fixtures/dataset-glossarist-v3", __dir__)
+  end
+
+  let(:collection) do
+    c = Glossarist::ManagedConceptCollection.new
+    c.load_from_files(v3_path)
+    c
+  end
+
+  let(:register) { Glossarist::DatasetRegister.from_directory(v3_path) }
+
+  let(:parent_concept) { collection.find { |c| c.data&.id == "1.1" } }
+  let(:child_concept) { collection.find { |c| c.data&.id == "1.1.1" } }
+
+  describe "with a DatasetRegister (V3 canonical)" do
+    it "matches the concept's direct section" do
+      cascade = described_class.new(register)
+      expect(cascade.member?(parent_concept, "3")).to be(true)
+    end
+
+    it "cascades to ancestor sections" do
+      cascade = described_class.new(register)
+      # 1.1.1 has explicit domain 3.1; cascading should match ancestor 3
+      expect(cascade.member?(child_concept, "3.1")).to be(true)
+      expect(cascade.member?(child_concept, "3")).to be(true)
+    end
+
+    it "does not match a sibling section" do
+      cascade = described_class.new(register)
+      expect(cascade.member?(child_concept, "other")).to be(false)
+    end
+
+    it "does not match a descendant the concept is not in" do
+      cascade = described_class.new(register)
+      # parent concept 1.1 is in section 3 directly, not 3.1
+      expect(cascade.member?(parent_concept, "3.1")).to be(false)
+    end
+  end
+
+  describe "without a register (legacy fallback)" do
+    it "matches the concept's explicit domain section" do
+      cascade = described_class.new(nil)
+      expect(cascade.member?(parent_concept, "3")).to be(true)
+    end
+
+    it "matches the concept's explicit nested section" do
+      cascade = described_class.new(nil)
+      expect(cascade.member?(child_concept, "3.1")).to be(true)
+    end
+
+    it "cannot cascade to ancestor without a register" do
+      cascade = described_class.new(nil)
+      expect(cascade.member?(child_concept, "3")).to be(false)
+    end
+  end
+
+  describe "edge cases" do
+    it "returns false for nil concept" do
+      expect(described_class.new(register).member?(nil, "3")).to be(false)
+    end
+
+    it "returns false for concept without data" do
+      cascade = described_class.new(register)
+      bare = Struct.new(:data).new(nil)
+      expect(cascade.member?(bare, "3")).to be(false)
+    end
+  end
+end

--- a/spec/metanorma/plugin/glossarist/section_renderer_spec.rb
+++ b/spec/metanorma/plugin/glossarist/section_renderer_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Metanorma::Plugin::Glossarist::SectionRenderer do
+  let(:v3_path) do
+    File.expand_path("../../../fixtures/dataset-glossarist-v3", __dir__)
+  end
+
+  let(:collection) do
+    c = Glossarist::ManagedConceptCollection.new
+    c.load_from_files(v3_path)
+    c
+  end
+
+  let(:register) { Glossarist::DatasetRegister.from_directory(v3_path) }
+  let(:sections) { register.sections }
+
+  def new_renderer(dataset: collection.to_a, **opts)
+    renderer = Metanorma::Plugin::Glossarist::TemplateRenderer.new(
+      file_system: File.dirname(v3_path),
+    )
+    described_class.new(
+      dataset: dataset, register: register,
+      renderer: renderer, **opts
+    )
+  end
+
+  describe "#render" do
+    it "renders one block per non-empty section" do
+      parts = new_renderer(depth: 2).render(sections)
+      expect(parts.length).to eq(1)
+      expect(parts.first).to start_with("=== ")
+    end
+
+    it "uses section name in heading when available" do
+      parts = new_renderer(depth: 2).render(sections)
+      section = register.section_by_id("3")
+      expect(parts.first).to include("=== #{section.name}")
+    end
+
+    it "cascades ancestor section membership via register" do
+      only_section_three = sections.select { |s| s.id == "3" }
+      body = new_renderer(depth: 2).render(only_section_three).first
+      expect(body).to include("parent concept")
+      expect(body).to include("child concept")
+    end
+
+    it "skips sections that have no matching concepts" do
+      parts = new_renderer(depth: 2).render(sections)
+      expect(parts.length).to eq(1)
+    end
+
+    it "yields matched concepts to the caller" do
+      accumulated = []
+      new_renderer(depth: 2).render(sections) do |concepts|
+        accumulated.concat(concepts)
+      end
+      ids = accumulated.map { |c| c.data&.id }
+      expect(ids).to include("1.1", "1.1.1")
+    end
+
+    it "respects custom sort_by option" do
+      default = new_renderer(depth: 2)
+      custom = new_renderer(depth: 2, sort_by: "data.id")
+      expect(default.render(sections)).not_to be_empty
+      expect(custom.render(sections)).not_to be_empty
+    end
+
+    it "renders heading at depth + 1" do
+      parts = new_renderer(depth: 3).render(sections)
+      expect(parts.first).to start_with("==== ")
+    end
+
+    it "passes anchor_prefix to the concept renderer" do
+      parts = new_renderer(depth: 2, anchor_prefix: "pre").render(sections)
+      expect(parts.first).to include("[[pre1.1]]")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Bumps minimum glossarist to 2.8.16 to adopt the typed V3 models (`BibliographyData`, `BibliographyEntry`, `DatasetRegister`, `Section`).
- Refactors `DatasetRegistry` to be the single source of truth, exposing `register_for`, `bibliography_for`, and `concepts_at` as canonical entry points backed by typed Glossarist models.
- Modernizes `BibliographyRenderer` to consume a `BibliographyData` model and read `BibliographyEntry` typed accessors (`#reference`, `#title`, `#link`) instead of raw hash keys.
- Adds `SectionCascade` MECE collaborator for transitive ancestor section membership (gloss:hasChildSection is owl:TransitiveProperty — a concept in 3.1.1 is also in 3.1 and 3).
- `ConceptFilter#apply` now takes `register:` and delegates section filtering to `SectionCascade`.
- Extracts `SectionRenderer` from `DatasetPreprocessor` to keep section rendering concerns in one place and shrink the preprocessor below rubocop thresholds.
- Canonicalizes the V3 fixtures: `register.yaml` with `schema_type`/`schema_version` and nested sections, `bibliography.yaml` in single-key wrapped V3 format.

## Design notes

- OCP: cascading, section rendering, and bibliography lookups are each isolated collaborators composed by the preprocessor — adding new flavors does not require touching the preprocessor.
- MECE: each concern lives in exactly one class (`SectionCascade` for membership, `SectionFilter` for include/exclude, `SectionRenderer` for per-section rendering, `BibliographyRenderer` for citation rendering).
- Model-driven: callers never poke at raw YAML hashes; everything flows through the typed Glossarist model.
- No doubles in specs — all new tests use real `Glossarist::BibliographyData`, `BibliographyEntry`, `DatasetRegister`, `ManagedConceptCollection`, and `Section` instances.

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rspec` — 202 examples, 0 failures (1 pending on glossarist annotation parsing)
- [ ] CI green on this PR
- [ ] Manual smoke: render an existing document that uses `glossarist::import_sections[]` and `glossarist::render_bibliography[]`
