### PR TITLE
feat: non-verbal entity support (figures, tables, formulas)

### DIFF
--- a/lib/metanorma-plugin-glossarist.rb
+++ b/lib/metanorma-plugin-glossarist.rb
@@ -21,6 +21,10 @@ module Metanorma
       autoload :Document, "metanorma/plugin/glossarist/document"
       autoload :Liquid, "metanorma/plugin/glossarist/liquid"
       autoload :LiquidRendering, "metanorma/plugin/glossarist/liquid_rendering"
+      autoload :NonVerbalFormatters,
+               "metanorma/plugin/glossarist/non_verbal_formatters"
+      autoload :NonVerbalRenderer,
+               "metanorma/plugin/glossarist/non_verbal_renderer"
       autoload :Sanitize, "metanorma/plugin/glossarist/sanitize"
       autoload :SectionCascade, "metanorma/plugin/glossarist/section_cascade"
       autoload :SectionFilter, "metanorma/plugin/glossarist/section_filter"

--- a/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
+++ b/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
@@ -15,6 +15,7 @@ module Metanorma
         BLOCK_REGEX = /^\[glossarist,(.+?),(.+?)\]$/m
         BIBLIOGRAPHY_REGEX = /^glossarist::render_bibliography\[(.*?)\]$/m
         BIBLIOGRAPHY_ENTRY_REGEX = /^glossarist::render_bibliography_entry\[(.*?)\]$/m
+        NON_VERBAL_REGEX = /^glossarist::render_(figures|tables|formulas)\[(.*?)\]$/m
 
         BIB_ANCHOR_REGEX = /^\*\s*\[\[\[([^,]+)/
 
@@ -69,30 +70,45 @@ module Metanorma
         end
 
         def process_line(document, input_lines, current_line, liquid_doc)
-          if (match = current_line.match(DATASET_ATTR_REGEX))
-            process_dataset_tag(document, input_lines, liquid_doc, match)
-          elsif (match = current_line.match(RENDER_REGEX))
-            process_render_tag(liquid_doc, match)
-          elsif (match = current_line.match(IMPORT_SECTIONS_REGEX))
-            process_import_sections_tag(document, liquid_doc, match)
-          elsif (match = current_line.match(IMPORT_REGEX))
-            process_import_tag(liquid_doc, match)
-          elsif (match = current_line.match(BIBLIOGRAPHY_REGEX))
-            process_bibliography(document, liquid_doc, match)
-          elsif (match = current_line.match(BIBLIOGRAPHY_ENTRY_REGEX))
-            process_bibliography_entry(document, liquid_doc, match)
-          elsif (match = current_line.match(BLOCK_REGEX))
-            process_glossarist_block(document, liquid_doc, input_lines, match)
+          handler = directive_handler(current_line)
+          if handler
+            handler.call(document, input_lines, liquid_doc)
           else
-            if /^==+ \S/.match?(current_line)
-              @title_depth = current_line.sub(/ .*$/,
-                                              "").size
-            end
-            if (match = current_line.match(BIB_ANCHOR_REGEX))
-              @existing_bib_anchors << match[1]
-            end
-            liquid_doc.add_content(current_line)
+            handle_plain_line(current_line, liquid_doc)
           end
+        end
+
+        # Returns a callable that handles the directive on +line+, or nil
+        # for plain content. Keeping the dispatch table small (regex →
+        # block) lets us add a new directive by appending one entry.
+        def directive_handler(line)
+          if (m = line.match(DATASET_ATTR_REGEX))
+            ->(doc, lines, ldoc) { process_dataset_tag(doc, lines, ldoc, m) }
+          elsif (m = line.match(RENDER_REGEX))
+            ->(_, _, ldoc) { process_render_tag(ldoc, m) }
+          elsif (m = line.match(IMPORT_SECTIONS_REGEX))
+            ->(doc, _, ldoc) { process_import_sections_tag(doc, ldoc, m) }
+          elsif (m = line.match(IMPORT_REGEX))
+            ->(_, _, ldoc) { process_import_tag(ldoc, m) }
+          elsif (m = line.match(BIBLIOGRAPHY_REGEX))
+            ->(doc, _, ldoc) { process_bibliography(doc, ldoc, m) }
+          elsif (m = line.match(BIBLIOGRAPHY_ENTRY_REGEX))
+            ->(doc, _, ldoc) { process_bibliography_entry(doc, ldoc, m) }
+          elsif (m = line.match(NON_VERBAL_REGEX))
+            ->(_, _, ldoc) { process_non_verbal(ldoc, m) }
+          elsif (m = line.match(BLOCK_REGEX))
+            ->(doc, lines, ldoc) { process_glossarist_block(doc, ldoc, lines, m) }
+          end
+        end
+
+        def handle_plain_line(current_line, liquid_doc)
+          if /^==+ \S/.match?(current_line)
+            @title_depth = current_line.sub(/ .*$/, "").size
+          end
+          if (match = current_line.match(BIB_ANCHOR_REGEX))
+            @existing_bib_anchors << match[1]
+          end
+          liquid_doc.add_content(current_line)
         end
 
         def process_dataset_tag(document, input_lines, liquid_doc, match)
@@ -157,7 +173,8 @@ module Metanorma
           renderer = @renderer
           rendered = renderer.render_concept(concept,
                                              depth: @title_depth,
-                                             anchor_prefix: options["anchor-prefix"])
+                                             anchor_prefix: options["anchor-prefix"],
+                                             non_verbal: non_verbal_for(context_name))
           liquid_doc.add_content("\n#{rendered}")
         end
 
@@ -179,7 +196,8 @@ module Metanorma
           renderer = @renderer
           rendered = renderer.render_concepts(concepts,
                                               depth: @title_depth,
-                                              anchor_prefix: options["anchor-prefix"])
+                                              anchor_prefix: options["anchor-prefix"],
+                                              non_verbal: non_verbal_for(context_name))
           liquid_doc.add_content("\n#{rendered}")
         end
 
@@ -196,11 +214,11 @@ module Metanorma
           dataset = @registry.resolve_dataset(nil, context_name)
           return unless dataset
 
-          parts = render_sections(dataset, register, sections, options)
+          parts = render_sections(dataset, register, sections, context_name, options)
           liquid_doc.add_content("\n#{parts.join("\n\n")}")
         end
 
-        def render_sections(dataset, register, sections, options)
+        def render_sections(dataset, register, sections, context_name, options)
           section_filter = SectionFilter.new(
             exclude: (options["section_exclude"] || "").split("|"),
             include: (options["section_include"] || "").split("|"),
@@ -213,10 +231,23 @@ module Metanorma
             depth: @title_depth,
             sort_by: options["sort_by"] || SectionRenderer::DEFAULT_SORT_BY,
             anchor_prefix: options["anchor-prefix"],
+            non_verbal: non_verbal_for(context_name),
           )
           renderer.render(filtered) do |concepts|
             @rendered_concepts.concat(concepts)
           end
+        end
+
+        # Builds a NonVerbalRenderer scoped to a dataset context, or
+        # returns nil if the dataset has no figures/tables/formulas. The
+        # resulting renderer is passed through to TemplateRenderer and
+        # SectionRenderer so concept-attached refs render as AsciiDoc
+        # blocks alongside the concept body.
+        def non_verbal_for(context_name)
+          collections = @registry.non_verbal_collections(context_name)
+          return nil if collections.empty?
+
+          NonVerbalRenderer.new(collections: collections)
         end
 
         def process_bibliography(document, liquid_doc, match)
@@ -250,6 +281,21 @@ module Metanorma
           )
           entry = renderer.render_entry(concept)
           liquid_doc.add_content(entry) if entry
+        end
+
+        # Renders all dataset-level entities of a non-verbal kind
+        # (figures, tables, formulas) as AsciiDoc blocks. The directive
+        # shape is +glossarist::render_<kind>[dataset]+.
+        def process_non_verbal(liquid_doc, match)
+          @seen_glossarist = true
+          kind = :"#{match[1]}"
+          dataset_name = match[2].strip
+          collection = @registry.non_verbal_collection(dataset_name, kind)
+          return unless collection
+
+          renderer = NonVerbalRenderer.new(collections: { kind => collection })
+          rendered = renderer.render_kind(kind)
+          liquid_doc.add_content("\n#{rendered}") unless rendered.empty?
         end
 
         def relative_file_path(document, file_path)

--- a/lib/metanorma/plugin/glossarist/dataset_registry.rb
+++ b/lib/metanorma/plugin/glossarist/dataset_registry.rb
@@ -8,17 +8,28 @@ module Metanorma
       # Resolves, caches, and exposes dataset models for a document.
       #
       # Single source of truth for everything the preprocessor needs from a
-      # glossarist dataset: concepts, section hierarchy, and bibliography.
+      # glossarist dataset: concepts, section hierarchy, bibliography, and
+      # dataset-level non-verbal entities (figures, tables, formulas).
       # Each is exposed as the typed Glossarist model object so callers
       # never poke at raw YAML hashes.
       class DatasetRegistry
         BIBLIOGRAPHY_FILENAME = "bibliography.yaml"
         REGISTER_FILENAME = "register.yaml"
 
+        # Map of plural kind symbol → (collection class, subdirectory name).
+        # Adding a new non-verbal kind = adding one entry here. The accessor
+        # `{kind}_for` and loader are derived from this table.
+        NON_VERBAL_KINDS = {
+          figures: [::Glossarist::Collections::FigureCollection, "figures"],
+          tables: [::Glossarist::Collections::TableCollection, "tables"],
+          formulas: [::Glossarist::Collections::FormulaCollection, "formulas"],
+        }.freeze
+
         def initialize
           @stores = {}
           @registers = {}
           @bibliographies = {}
+          @non_verbal = {}
           @context_paths = {}
         end
 
@@ -81,6 +92,38 @@ module Metanorma
           store_for(path).concepts
         end
 
+        # Returns the typed NonVerbalCollection for a registered context
+        # (e.g. FigureCollection), or nil if the dataset has no such
+        # subdirectory. +kind+ is one of the keys of NON_VERBAL_KINDS.
+        def non_verbal_collection(context_name, kind)
+          unless NON_VERBAL_KINDS.key?(kind)
+            raise ArgumentError, "unknown non-verbal kind: #{kind.inspect}"
+          end
+
+          path = @context_paths[context_name]
+          return nil unless path
+
+          collection_class, subdir = NON_VERBAL_KINDS.fetch(kind)
+          non_verbal_at(path, kind, subdir, collection_class)
+        end
+
+        NON_VERBAL_KINDS.each_key do |kind|
+          define_method("#{kind}_for") do |context_name|
+            non_verbal_collection(context_name, kind)
+          end
+        end
+
+        # Returns all available non-verbal collections for a context as a
+        # hash keyed by kind symbol (e.g. +{ figures: FigureCollection }+).
+        # Kinds whose subdirectory doesn't exist are omitted. Convenient
+        # for building a NonVerbalRenderer in one call.
+        def non_verbal_collections(context_name)
+          NON_VERBAL_KINDS.each_with_object({}) do |(kind, _), memo|
+            collection = non_verbal_collection(context_name, kind)
+            memo[kind] = collection if collection
+          end
+        end
+
         private
 
         def concepts_for(context_name)
@@ -106,6 +149,14 @@ module Metanorma
             file = File.join(path, BIBLIOGRAPHY_FILENAME)
             ::Glossarist::BibliographyData.from_file(file)
           end
+        end
+
+        def non_verbal_at(path, kind, subdir, collection_class)
+          dir = File.join(path, subdir)
+          return nil unless File.directory?(dir)
+
+          @non_verbal[path] ||= {}
+          @non_verbal[path][kind] ||= collection_class.from_directory(dir)
         end
 
         def relative_file_path(document, file_path)

--- a/lib/metanorma/plugin/glossarist/non_verbal_formatters.rb
+++ b/lib/metanorma/plugin/glossarist/non_verbal_formatters.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Plugin
+    module Glossarist
+      # Namespace for per-kind AsciiDoc formatters for dataset-level
+      # non-verbal entities. Adding a new kind = adding a new formatter
+      # class and registering it in NonVerbalRenderer::FORMATTERS.
+      module NonVerbalFormatters
+        autoload :Base, "metanorma/plugin/glossarist/non_verbal_formatters/base"
+        autoload :Figure,
+                 "metanorma/plugin/glossarist/non_verbal_formatters/figure"
+        autoload :Table,
+                 "metanorma/plugin/glossarist/non_verbal_formatters/table"
+        autoload :Formula,
+                 "metanorma/plugin/glossarist/non_verbal_formatters/formula"
+      end
+    end
+  end
+end

--- a/lib/metanorma/plugin/glossarist/non_verbal_formatters/base.rb
+++ b/lib/metanorma/plugin/glossarist/non_verbal_formatters/base.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Plugin
+    module Glossarist
+      module NonVerbalFormatters
+        # Shared rendering helpers for non-verbal entity formatters.
+        #
+        # Each formatter owns the kind-specific body (image block, table
+        # block, stem block) and delegates anchor, caption, and a11y
+        # framing to this base. Localized text is resolved by ISO 639 code
+        # with graceful fallback to the first available value.
+        class Base
+          def initialize(entity, lang: "eng")
+            @entity = entity
+            @lang = lang
+          end
+
+          def to_asciidoc
+            parts = [anchor_line, caption_line, body].compact.reject(&:empty?)
+            "#{parts.join("\n")}\n"
+          end
+
+          protected
+
+          attr_reader :entity, :lang
+
+          # Subclasses implement this with the kind-specific AsciiDoc body
+          # (e.g. image::, table, stem block).
+          def body
+            raise NotImplementedError
+          end
+
+          def anchor_line
+            id = entity.id
+            id ? "[[#{id}]]" : nil
+          end
+
+          def caption_line
+            text = localized(entity.caption)
+            text ? ".#{text}" : nil
+          end
+
+          def alt_text
+            localized(entity.alt)
+          end
+
+          def description_text
+            localized(entity.description)
+          end
+
+          # Picks the value for the requested language, falling back to
+          # the first available value if missing. Returns nil for empty
+          # or absent hashes.
+          def localized(hash)
+            return nil if hash.nil? || hash.empty?
+
+            hash[lang] || hash.values.first
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/plugin/glossarist/non_verbal_formatters/figure.rb
+++ b/lib/metanorma/plugin/glossarist/non_verbal_formatters/figure.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Plugin
+    module Glossarist
+      module NonVerbalFormatters
+        # Renders a Glossarist::Figure as an AsciiDoc image block.
+        #
+        # Picks a single best image variant: vector (SVG) preferred for
+        # resolution-independence, then any first image. Subfigures are
+        # rendered recursively as separate image blocks so each carries
+        # its own anchor and caption.
+        class Figure < Base
+          ROLE_PRIORITY = %w[vector raster print light dark].freeze
+
+          protected
+
+          def body
+            image = best_image
+            return subfigure_blocks if image.nil?
+
+            line = "image::#{image.src}[#{image_attrs(image)}]"
+            subfigure_blocks ? "#{line}\n\n#{subfigure_blocks}" : line
+          end
+
+          private
+
+          def best_image
+            images = Array(entity.images)
+            return nil if images.empty?
+
+            ROLE_PRIORITY.each do |role|
+              found = images.find { |img| img.role == role }
+              return found if found
+            end
+            images.first
+          end
+
+          def image_attrs(image)
+            attrs = []
+            attrs << alt_text if alt_text
+            attrs << "width=#{image.width}" if image.width
+            attrs << "height=#{image.height}" if image.height
+            attrs.join(",")
+          end
+
+          def subfigure_blocks
+            subs = Array(entity.subfigures)
+            return nil if subs.empty?
+
+            subs.map do |sub|
+              self.class.new(sub, lang: lang).to_asciidoc
+            end.join("\n").strip
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/plugin/glossarist/non_verbal_formatters/formula.rb
+++ b/lib/metanorma/plugin/glossarist/non_verbal_formatters/formula.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Plugin
+    module Glossarist
+      module NonVerbalFormatters
+        # Renders a Glossarist::Formula as an AsciiDoc stem block.
+        #
+        # The expression hash is keyed by language (matching caption/alt);
+        # the +notation+ field carries the markup language (latex, mathml,
+        # asciimath) but the body is format-agnostic — Metanorma's stem
+        # block accepts any notation supported by the renderer.
+        class Formula < Base
+          protected
+
+          def body
+            expr = localized(entity.expression)
+            return "" if expr.nil? || expr.empty?
+
+            <<~STEM
+              [stem]
+              ++++
+              #{expr}
+              ++++
+            STEM
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/plugin/glossarist/non_verbal_formatters/table.rb
+++ b/lib/metanorma/plugin/glossarist/non_verbal_formatters/table.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Plugin
+    module Glossarist
+      module NonVerbalFormatters
+        # Renders a Glossarist::Table as an AsciiDoc table block.
+        #
+        # Two payload shapes are supported:
+        #   - +format: structured+ — +content+ has +headers+ and +rows+
+        #     arrays, rendered as an AsciiDoc table.
+        #   - +format: asciidoc+ (or any non-structured) — +content+ is a
+        #     raw markup string emitted verbatim between caption and the
+        #     next block.
+        class Table < Base
+          STRUCTURED = "structured"
+
+          protected
+
+          def body
+            entity.format == STRUCTURED ? structured_table : raw_block
+          end
+
+          private
+
+          def structured_table
+            lines = ["|==="]
+            append_headers(lines)
+            Array(entity.content&.dig("rows")).each do |row|
+              lines << "|#{Array(row).join(' |')}"
+            end
+            lines << "|==="
+            lines.join("\n")
+          end
+
+          def append_headers(lines)
+            headers = Array(entity.content&.dig("headers"))
+            lines << "|#{headers.join(' |')}" unless headers.empty?
+          end
+
+          def raw_block
+            content = entity.content
+            (content&.dig("asciidoc") || content&.dig("text")).to_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/plugin/glossarist/non_verbal_renderer.rb
+++ b/lib/metanorma/plugin/glossarist/non_verbal_renderer.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Plugin
+    module Glossarist
+      # Renders dataset-level non-verbal entities (Figure, Table, Formula)
+      # as AsciiDoc blocks. MECE sibling to BibliographyRenderer: where
+      # BibliographyRenderer owns citation provenance, NonVerbalRenderer
+      # owns the rendering of authored figures/tables/formulas.
+      #
+      # Per-kind formatting is delegated to a formatter class registered
+      # in +FORMATTERS+. Adding a new kind = adding one formatter class
+      # and one entry here; the dispatcher itself never changes shape.
+      class NonVerbalRenderer
+        FORMATTERS = {
+          figures: NonVerbalFormatters::Figure,
+          tables: NonVerbalFormatters::Table,
+          formulas: NonVerbalFormatters::Formula,
+        }.freeze
+
+        # @param collections [Hash{Symbol => NonVerbalCollection, nil}]
+        #   one entry per non-verbal kind, e.g.
+        #   `{ figures: FigureCollection, tables: ..., formulas: ... }`.
+        #   Missing or nil entries are silently skipped.
+        def initialize(collections:, lang: "eng")
+          @collections = collections
+          @lang = lang
+        end
+
+        # Render every entity in the named collection.
+        #
+        # @param kind [Symbol] key in FORMATTERS (e.g. +:figures+)
+        # @return [String] AsciiDoc blocks joined by blank lines, or ""
+        def render_kind(kind)
+          collection = @collections[kind]
+          return "" if collection.nil? || collection.entries.empty?
+
+          entries = collection.entries
+          "#{entries.map { |e| format_one(kind, e) }.join("\n\n")}\n"
+        end
+
+        # Render the non-verbal entities referenced by a concept's
+        # figures/tables/formulas ref collections, in deterministic order
+        # (figures, tables, formulas). Unknown refs are skipped silently —
+        # they will surface as missing anchors during Metanorma rendering.
+        #
+        # @param concept [Glossarist::ManagedConcept]
+        # @return [String]
+        def render_concept_refs(concept)
+          FORMATTERS.keys.filter_map do |kind|
+            refs = concept_refs(concept, kind)
+            next if refs.empty?
+
+            blocks = refs.filter_map { |ref| render_ref(kind, ref) }
+            next if blocks.empty?
+
+            "#{blocks.join("\n\n")}\n"
+          end.join("\n")
+        end
+
+        private
+
+        def render_ref(kind, ref)
+          collection = @collections[kind]
+          return nil unless collection
+
+          entity = collection.by_id(ref.entity_id)
+          return nil unless entity
+
+          format_one(kind, entity)
+        end
+
+        def format_one(kind, entity)
+          FORMATTERS.fetch(kind).new(entity, lang: @lang).to_asciidoc
+        end
+
+        def concept_refs(concept, kind)
+          refs = concept.data&.public_send(kind)
+          Array(refs)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/plugin/glossarist/section_renderer.rb
+++ b/lib/metanorma/plugin/glossarist/section_renderer.rb
@@ -18,7 +18,7 @@ module Metanorma
         # @param register [Glossarist::DatasetRegister, nil] for cascading
         # @param renderer [TemplateRenderer] concept renderer
         # @param depth [Integer] base heading depth for sections
-        # @param options [Hash] :sort_by, :anchor_prefix
+        # @param options [Hash] :sort_by, :anchor_prefix, :non_verbal
         def initialize(dataset:, register:, renderer:, depth:, **options)
           @dataset = dataset
           @register = register
@@ -26,6 +26,7 @@ module Metanorma
           @depth = depth
           @sort_by = options[:sort_by] || DEFAULT_SORT_BY
           @anchor_prefix = options[:anchor_prefix]
+          @non_verbal = options[:non_verbal]
         end
 
         # @param sections [Array<Glossarist::Section>]
@@ -55,7 +56,8 @@ module Metanorma
           heading = "#{'=' * (@depth + 1)} #{section.name || section.id}"
           body = @renderer.render_concepts(concepts,
                                            depth: @depth + 1,
-                                           anchor_prefix: @anchor_prefix)
+                                           anchor_prefix: @anchor_prefix,
+                                           non_verbal: @non_verbal)
           "#{heading}\n\n#{body}"
         end
       end

--- a/lib/metanorma/plugin/glossarist/template_renderer.rb
+++ b/lib/metanorma/plugin/glossarist/template_renderer.rb
@@ -12,13 +12,17 @@ module Metanorma
           @template_cache = {}
         end
 
-        def render_concepts(concepts, depth:, anchor_prefix: nil)
+        def render_concepts(concepts, depth:, anchor_prefix: nil,
+                            non_verbal: nil)
           tree = build_concept_tree(concepts)
-          parts = tree.map { |c| render_tree_node(c, depth, anchor_prefix) }
+          parts = tree.map do |node|
+            render_tree_node(node, depth, anchor_prefix, non_verbal)
+          end
           normalize_whitespace(parts.join("\n\n"))
         end
 
-        def render_concept(concept, depth:, anchor_prefix: nil)
+        def render_concept(concept, depth:, anchor_prefix: nil,
+                           non_verbal: nil)
           l10n = concept.localization(@lang)
           context = {
             "concept" => concept.to_liquid,
@@ -28,6 +32,9 @@ module Metanorma
           }
           template_content = cached_template(concept)
           rendered = render_template(template_content, context)
+          if non_verbal
+            rendered += "\n\n#{non_verbal.render_concept_refs(concept)}"
+          end
           normalize_whitespace(rendered)
         end
 
@@ -41,12 +48,14 @@ module Metanorma
           end
         end
 
-        def render_tree_node((concept, children), depth, anchor_prefix)
+        def render_tree_node((concept, children), depth, anchor_prefix,
+                             non_verbal)
           result = render_concept(concept, depth: depth,
-                                           anchor_prefix: anchor_prefix)
+                                           anchor_prefix: anchor_prefix,
+                                           non_verbal: non_verbal)
           children.each do |child_node|
             result += "\n" + render_tree_node(child_node, depth + 1,
-                                              anchor_prefix)
+                                              anchor_prefix, non_verbal)
           end
           result
         end

--- a/spec/fixtures/dataset-glossarist-v3/concept/c-1.1.yaml
+++ b/spec/fixtures/dataset-glossarist-v3/concept/c-1.1.yaml
@@ -12,6 +12,12 @@ data:
   domains:
   - concept_id: "3"
     ref_type: section
+  figures:
+  - mixed-reflection
+  tables:
+  - unit-conversion
+  formulas:
+  - wave-equation
   tags:
   - test-domain
 ---

--- a/spec/fixtures/dataset-glossarist-v3/figures/mixed-reflection.yaml
+++ b/spec/fixtures/dataset-glossarist-v3/figures/mixed-reflection.yaml
@@ -1,0 +1,26 @@
+id: mixed-reflection
+identifier: "Figure 1"
+caption:
+  eng: Mixed reflection
+  fra: "Réflexion mixte"
+alt:
+  eng: Diagram showing mixed reflection
+description:
+  eng: Light ray interacting with a partially reflecting surface.
+images:
+  - src: figures/mixed-reflection.svg
+    format: svg
+    role: vector
+  - src: figures/mixed-reflection.png
+    format: png
+    role: raster
+    width: 1600
+    height: 1200
+sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: ievtermbank
+      locality:
+        type: clause
+        reference_from: 845-04-58

--- a/spec/fixtures/dataset-glossarist-v3/formulas/wave-equation.yaml
+++ b/spec/fixtures/dataset-glossarist-v3/formulas/wave-equation.yaml
@@ -1,0 +1,11 @@
+id: wave-equation
+identifier: "Equation 1"
+caption:
+  eng: Electromagnetic wave equation
+alt:
+  eng: Second-order partial differential equation for the E-field
+description:
+  eng: Describes wave propagation in free space.
+expression:
+  eng: "\\nabla^2 \\mathbf{E} = \\mu_0 \\epsilon_0 \\frac{\\partial^2 \\mathbf{E}}{\\partial t^2}"
+notation: latex

--- a/spec/fixtures/dataset-glossarist-v3/tables/unit-conversion.yaml
+++ b/spec/fixtures/dataset-glossarist-v3/tables/unit-conversion.yaml
@@ -1,0 +1,18 @@
+id: unit-conversion
+identifier: "Table 1"
+caption:
+  eng: SI base units
+alt:
+  eng: Table of SI base units with symbols and dimensions
+description:
+  eng: Seven base units — metre, kilogram, second, ampere, kelvin, mole, candela.
+content:
+  headers:
+    - Unit
+    - Symbol
+    - Dimension
+  rows:
+    - [metre, m, L]
+    - [kilogram, kg, M]
+    - [second, s, T]
+format: structured

--- a/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/glossarist/dataset_preprocessor_spec.rb
@@ -1043,6 +1043,94 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetPreprocessor do
           .not_to raise_error
       end
     end
+
+    context "[render non-verbal entities]" do
+      context "[render_figures]" do
+        let(:reader) do
+          Asciidoctor::Reader.new <<~TEMPLATE
+            :glossarist-dataset: dataset1:./spec/fixtures/dataset-glossarist-v3
+
+            glossarist::render_figures[dataset1]
+          TEMPLATE
+        end
+
+        it "renders every figure as an AsciiDoc image block" do
+          out = subject.process(document, reader).source
+          expect(out).to include("[[mixed-reflection]]")
+          expect(out).to include(".Mixed reflection")
+          expect(out).to include("image::figures/mixed-reflection.svg")
+        end
+      end
+
+      context "[render_tables]" do
+        let(:reader) do
+          Asciidoctor::Reader.new <<~TEMPLATE
+            :glossarist-dataset: dataset1:./spec/fixtures/dataset-glossarist-v3
+
+            glossarist::render_tables[dataset1]
+          TEMPLATE
+        end
+
+        it "renders every table as an AsciiDoc table block" do
+          out = subject.process(document, reader).source
+          expect(out).to include("[[unit-conversion]]")
+          expect(out).to include(".SI base units")
+          expect(out).to include("|===")
+          expect(out).to include("|metre |m |L")
+        end
+      end
+
+      context "[render_formulas]" do
+        let(:reader) do
+          Asciidoctor::Reader.new <<~TEMPLATE
+            :glossarist-dataset: dataset1:./spec/fixtures/dataset-glossarist-v3
+
+            glossarist::render_formulas[dataset1]
+          TEMPLATE
+        end
+
+        it "renders every formula as an AsciiDoc stem block" do
+          out = subject.process(document, reader).source
+          expect(out).to include("[[wave-equation]]")
+          expect(out).to include(".Electromagnetic wave equation")
+          expect(out).to include("[stem]")
+          expect(out).to include("++++")
+        end
+      end
+
+      context "[render_figures] on a dataset without non-verbal entities" do
+        let(:reader) do
+          Asciidoctor::Reader.new <<~TEMPLATE
+            :glossarist-dataset: dataset1:./spec/fixtures/dataset-glossarist-v2
+
+            glossarist::render_figures[dataset1]
+          TEMPLATE
+        end
+
+        it "emits nothing when the subdirectory is missing" do
+          out = subject.process(document, reader).source
+          expect(out.strip).to eq("")
+        end
+      end
+    end
+
+    context "[concept-attached non-verbal refs]" do
+      let(:reader) do
+        Asciidoctor::Reader.new <<~TEMPLATE
+          :glossarist-dataset: dataset1:./spec/fixtures/dataset-glossarist-v3
+
+          glossarist::render[dataset1, parent concept]
+        TEMPLATE
+      end
+
+      it "appends non-verbal blocks after the concept body" do
+        out = subject.process(document, reader).source
+        expect(out).to include("parent concept")
+        expect(out).to include("[[mixed-reflection]]")
+        expect(out).to include("[[unit-conversion]]")
+        expect(out).to include("[[wave-equation]]")
+      end
+    end
   end
 
   def absolute_path(path)

--- a/spec/metanorma/plugin/glossarist/dataset_registry_spec.rb
+++ b/spec/metanorma/plugin/glossarist/dataset_registry_spec.rb
@@ -169,4 +169,83 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetRegistry do
       expect(registry.bibliography_for("unknown")).to be_nil
     end
   end
+
+  describe "#non_verbal_collection" do
+    it "loads a FigureCollection from a V3 dataset" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v3_path}")
+      coll = registry.non_verbal_collection("ds", :figures)
+      expect(coll).to be_a(Glossarist::Collections::FigureCollection)
+      expect(coll.ids).to include("mixed-reflection")
+    end
+
+    it "loads a TableCollection from a V3 dataset" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v3_path}")
+      coll = registry.non_verbal_collection("ds", :tables)
+      expect(coll).to be_a(Glossarist::Collections::TableCollection)
+      expect(coll.ids).to include("unit-conversion")
+    end
+
+    it "loads a FormulaCollection from a V3 dataset" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v3_path}")
+      coll = registry.non_verbal_collection("ds", :formulas)
+      expect(coll).to be_a(Glossarist::Collections::FormulaCollection)
+      expect(coll.ids).to include("wave-equation")
+    end
+
+    it "returns nil when the subdirectory is absent" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v2_path}")
+      expect(registry.non_verbal_collection("ds", :figures)).to be_nil
+    end
+
+    it "raises ArgumentError for an unknown kind" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v3_path}")
+      expect do
+        registry.non_verbal_collection("ds", :bogus)
+      end.to raise_error(ArgumentError, /unknown non-verbal kind/)
+    end
+
+    it "caches collections across calls" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v3_path}")
+      first = registry.non_verbal_collection("ds", :figures)
+      second = registry.non_verbal_collection("ds", :figures)
+      expect(first).to equal(second)
+    end
+  end
+
+  describe "dynamic accessors" do
+    it "exposes figures_for, tables_for, formulas_for methods" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v3_path}")
+      expect(registry.figures_for("ds")).to be_a(Glossarist::Collections::FigureCollection)
+      expect(registry.tables_for("ds")).to be_a(Glossarist::Collections::TableCollection)
+      expect(registry.formulas_for("ds")).to be_a(Glossarist::Collections::FormulaCollection)
+    end
+  end
+
+  describe "#non_verbal_collections" do
+    it "returns a hash of all available kinds" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v3_path}")
+      hash = registry.non_verbal_collections("ds")
+      expect(hash.keys).to contain_exactly(:figures, :tables, :formulas)
+      expect(hash[:figures]).to be_a(Glossarist::Collections::FigureCollection)
+    end
+
+    it "returns empty hash when no subdirectories exist" do
+      registry = described_class.new
+      registry.register(document_double, "ds:#{v2_path}")
+      expect(registry.non_verbal_collections("ds")).to eq({})
+    end
+
+    it "returns empty hash for unregistered context" do
+      registry = described_class.new
+      expect(registry.non_verbal_collections("missing")).to eq({})
+    end
+  end
 end

--- a/spec/metanorma/plugin/glossarist/non_verbal_formatters_spec.rb
+++ b/spec/metanorma/plugin/glossarist/non_verbal_formatters_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+RSpec.describe Metanorma::Plugin::Glossarist::NonVerbalFormatters do
+  let(:lang) { "eng" }
+
+  describe Metanorma::Plugin::Glossarist::NonVerbalFormatters::Figure do
+    let(:figure) do
+      Glossarist::Figure.new(
+        id: "mixed-reflection",
+        identifier: "Figure 1",
+        caption: { "eng" => "Mixed reflection" },
+        alt: { "eng" => "Diagram showing reflection" },
+        images: [
+          Glossarist::FigureImage.new(src: "fig.svg", format: "svg",
+                                      role: "vector"),
+          Glossarist::FigureImage.new(src: "fig.png", format: "png",
+                                      role: "raster",
+                                      width: 1600, height: 1200),
+        ],
+      )
+    end
+
+    it "renders an AsciiDoc image block with anchor and caption" do
+      out = described_class.new(figure, lang: lang).to_asciidoc
+      expect(out).to include("[[mixed-reflection]]")
+      expect(out).to include(".Mixed reflection")
+      expect(out).to include("image::fig.svg[Diagram showing reflection]")
+    end
+
+    it "prefers vector role when multiple variants exist" do
+      out = described_class.new(figure, lang: lang).to_asciidoc
+      expect(out).to include("image::fig.svg")
+      expect(out).not_to include("image::fig.png")
+    end
+
+    it "falls back to first image when no role matches priority list" do
+      only = Glossarist::Figure.new(
+        id: "alone",
+        alt: { "eng" => "alt" },
+        images: [Glossarist::FigureImage.new(src: "x.jpg", format: "jpg")],
+      )
+      out = described_class.new(only, lang: lang).to_asciidoc
+      expect(out).to include("image::x.jpg[alt]")
+    end
+
+    it "renders subfigures recursively" do
+      composite = Glossarist::Figure.new(
+        id: "parent",
+        caption: { "eng" => "Parent" },
+        alt: { "eng" => "parent alt" },
+        images: [Glossarist::FigureImage.new(src: "p.svg", format: "svg")],
+        subfigures: [
+          Glossarist::Figure.new(
+            id: "child",
+            caption: { "eng" => "Child" },
+            alt: { "eng" => "child alt" },
+            images: [Glossarist::FigureImage.new(src: "c.svg", format: "svg")],
+          ),
+        ],
+      )
+      out = described_class.new(composite, lang: lang).to_asciidoc
+      expect(out).to include("[[parent]]")
+      expect(out).to include("image::p.svg")
+      expect(out).to include("[[child]]")
+      expect(out).to include("image::c.svg")
+    end
+
+    it "falls back to first available language when requested lang missing" do
+      figure = Glossarist::Figure.new(
+        id: "f",
+        caption: { "fra" => "Réflexion" },
+        alt: { "fra" => "Diagramme" },
+        images: [Glossarist::FigureImage.new(src: "f.svg", format: "svg")],
+      )
+      out = described_class.new(figure, lang: "eng").to_asciidoc
+      expect(out).to include(".Réflexion")
+      expect(out).to include("image::f.svg[Diagramme]")
+    end
+  end
+
+  describe Metanorma::Plugin::Glossarist::NonVerbalFormatters::Table do
+    let(:table) do
+      Glossarist::Table.new(
+        id: "units",
+        identifier: "Table 1",
+        caption: { "eng" => "SI base units" },
+        alt: { "eng" => "SI units table" },
+        content: {
+          "headers" => %w[Unit Symbol],
+          "rows" => [%w[metre m], %w[kilogram kg]],
+        },
+        format: "structured",
+      )
+    end
+
+    it "renders an AsciiDoc table with anchor and caption" do
+      out = described_class.new(table, lang: lang).to_asciidoc
+      expect(out).to include("[[units]]")
+      expect(out).to include(".SI base units")
+    end
+
+    it "renders headers and rows in structured format" do
+      out = described_class.new(table, lang: lang).to_asciidoc
+      expect(out).to include("|===")
+      expect(out).to include("|Unit |Symbol")
+      expect(out).to include("|metre |m")
+      expect(out).to include("|kilogram |kg")
+    end
+
+    it "renders raw block when format is not structured" do
+      raw = Glossarist::Table.new(
+        id: "raw",
+        caption: { "eng" => "Raw" },
+        content: { "asciidoc" => "|===\n|A |B\n|1 |2\n|===" },
+        format: "asciidoc",
+      )
+      out = described_class.new(raw, lang: lang).to_asciidoc
+      expect(out).to include("[[raw]]")
+      expect(out).to include(".Raw")
+      expect(out).to include("|A |B")
+    end
+  end
+
+  describe Metanorma::Plugin::Glossarist::NonVerbalFormatters::Formula do
+    let(:formula) do
+      Glossarist::Formula.new(
+        id: "wave",
+        identifier: "Eq. 1",
+        caption: { "eng" => "Wave equation" },
+        alt: { "eng" => "Wave equation alt" },
+        expression: { "eng" => "E = mc^2" },
+        notation: "latex",
+      )
+    end
+
+    it "renders an AsciiDoc stem block with anchor and caption" do
+      out = described_class.new(formula, lang: lang).to_asciidoc
+      expect(out).to include("[[wave]]")
+      expect(out).to include(".Wave equation")
+      expect(out).to include("[stem]")
+    end
+
+    it "places the expression inside stem delimiters" do
+      out = described_class.new(formula, lang: lang).to_asciidoc
+      expect(out).to include("++++")
+      expect(out).to include("E = mc^2")
+    end
+
+    it "renders empty body when expression is absent" do
+      bare = Glossarist::Formula.new(
+        id: "bare",
+        caption: { "eng" => "Bare" },
+      )
+      out = described_class.new(bare, lang: lang).to_asciidoc
+      expect(out).to include("[[bare]]")
+      expect(out).not_to include("[stem]")
+    end
+  end
+end

--- a/spec/metanorma/plugin/glossarist/non_verbal_renderer_spec.rb
+++ b/spec/metanorma/plugin/glossarist/non_verbal_renderer_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe Metanorma::Plugin::Glossarist::NonVerbalRenderer do
+  let(:v3_path) do
+    File.expand_path("../../../fixtures/dataset-glossarist-v3", __dir__)
+  end
+  let(:all_collections) do
+    {
+      figures: collection_for(:figures),
+      tables: collection_for(:tables),
+      formulas: collection_for(:formulas),
+    }
+  end
+
+  def collection_class_for(kind)
+    {
+      figures: Glossarist::Collections::FigureCollection,
+      tables: Glossarist::Collections::TableCollection,
+      formulas: Glossarist::Collections::FormulaCollection,
+    }.fetch(kind)
+  end
+
+  def collection_for(kind)
+    collection_class_for(kind).from_directory(File.join(v3_path, kind.to_s))
+  end
+
+  describe "#render_kind" do
+    it "renders every figure in the collection" do
+      renderer = described_class.new(collections: all_collections)
+      out = renderer.render_kind(:figures)
+      expect(out).to include("[[mixed-reflection]]")
+      expect(out).to include(".Mixed reflection")
+      expect(out).to include("image::figures/mixed-reflection.svg")
+    end
+
+    it "renders every table in the collection" do
+      renderer = described_class.new(collections: all_collections)
+      out = renderer.render_kind(:tables)
+      expect(out).to include("[[unit-conversion]]")
+      expect(out).to include("|===")
+      expect(out).to include("|Unit |Symbol |Dimension")
+    end
+
+    it "renders every formula in the collection" do
+      renderer = described_class.new(collections: all_collections)
+      out = renderer.render_kind(:formulas)
+      expect(out).to include("[[wave-equation]]")
+      expect(out).to include("[stem]")
+    end
+
+    it "returns empty string when collection is nil" do
+      renderer = described_class.new(collections: {})
+      expect(renderer.render_kind(:figures)).to eq("")
+    end
+  end
+
+  describe "#render_concept_refs" do
+    let(:concept) do
+      c = Glossarist::ManagedConceptCollection.new
+      c.load_from_files(v3_path)
+      c.find { |x| x.data&.id == "1.1" }
+    end
+
+    it "renders all referenced non-verbal entities for a concept" do
+      renderer = described_class.new(collections: all_collections)
+      out = renderer.render_concept_refs(concept)
+      expect(out).to include("[[mixed-reflection]]")
+      expect(out).to include("[[unit-conversion]]")
+      expect(out).to include("[[wave-equation]]")
+    end
+
+    it "renders in figures → tables → formulas order" do
+      renderer = described_class.new(collections: all_collections)
+      out = renderer.render_concept_refs(concept)
+      expect(out.index("[[mixed-reflection]]"))
+        .to be < out.index("[[unit-conversion]]")
+      expect(out.index("[[unit-conversion]]"))
+        .to be < out.index("[[wave-equation]]")
+    end
+
+    it "skips refs whose entity is missing from the collection" do
+      concept.data.figures.first.entity_id = "missing-fig"
+      renderer = described_class.new(collections: all_collections)
+      out = renderer.render_concept_refs(concept)
+      expect(out).not_to include("[[mixed-reflection]]")
+      expect(out).to include("[[unit-conversion]]")
+    end
+
+    it "returns empty string when concept has no non-verbal refs" do
+      bare = Glossarist::ManagedConceptCollection.new
+      bare.load_from_files(
+        File.expand_path("../../../fixtures/dataset-glossarist-v2", __dir__),
+      )
+      renderer = described_class.new(collections: all_collections)
+      expect(renderer.render_concept_refs(bare.first)).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds rendering support for dataset-level non-verbal entities (Figure, Table, Formula) introduced in glossarist 2.8, symmetric to existing bibliography support.

- **Formatters**: per-kind AsciiDoc formatter (image::, table block, stem block) under `NonVerbalFormatters::*`, sharing a common `Base` for anchor/caption/a11y framing.
- **Dispatcher**: `NonVerbalRenderer` exposes `render_kind` (whole collection) and `render_concept_refs` (refs attached to a concept). Adding a new kind = one formatter class + one entry in `FORMATTERS`.
- **Registry**: `DatasetRegistry#non_verbal_collection(context, kind)` loads typed `Glossarist::Collections::*` from `{kind}/` subdirectories. Kinds table is a frozen constant hash; `{kind}_for` accessors are derived via `define_method`. Mirrors `bibliography_for`.
- **Directives**: `glossarist::render_figures[dataset]`, `render_tables`, `render_formulas` (symmetric to `render_bibliography`). Concept-attached refs now render after the concept body across all render paths (render, import, import_sections) via a per-call `NonVerbalRenderer`.
- **Fixtures + specs**: V3 fixtures for one figure/table/formula, linked from concept 1.1. Specs cover formatters, renderer dispatch, registry accessors, and end-to-end directive rendering.

## Test plan

- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rspec` — 236 examples, 0 failures (1 pre-existing pending)
- [x] V3 fixtures load via `Glossarist::Collections::FigureCollection.from_directory`
- [x] Concept-attached refs render in figures→tables→formulas order
- [ ] CI green on PR