### PR TITLE
fix: unblock v0.4.0 release — move metanorma test deps to default group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,11 @@ gem "rubocop-rspec"
 
 gemspec
 
-group :test do
-  gem "metanorma"
-  gem "metanorma-plugin-lutaml"
-  gem "metanorma-standoc"
-end
+# metanorma / metanorma-standoc / metanorma-plugin-lutaml are needed by
+# spec_helper.rb at test time, but live in the default group (not :test)
+# so the release workflow's `bundle install --without development test`
+# still installs them. Bundler otherwise fails `bundle exec rake release`
+# with GemNotFound when the resolver walks the Gemfile.
+gem "metanorma"
+gem "metanorma-plugin-lutaml"
+gem "metanorma-standoc"


### PR DESCRIPTION
## Summary

- Move `metanorma`, `metanorma-plugin-lutaml`, `metanorma-standoc` from `:test` group to default group in Gemfile.

## Why

The v0.4.0 release publish stage failed with `Bundler::GemNotFound: metanorma-standoc`. Root cause: metanorma/ci's `rubygems-release.yml` workflow changed (post-2026-06-28) to run `bundle install --without development test` before `bundle exec rake release`. With these deps in `:test`, Bundler's resolver walks the Gemfile during `bundle exec` and fails because the test gems aren't installed.

The 0.3.10 release (2026-06-20) succeeded because the upstream workflow ran full `bundle install` at the time.

These deps still don't ship with the gem (they're in the Gemfile, not the gemspec) — runtime dependencies are unchanged.

## Test plan

- [x] `bundle install --without development test && bundle exec rake -T` resolves cleanly and shows the `release` task
- [x] `bundle exec rspec` — 262 examples, 0 failures, 1 pending
- [ ] Re-trigger `repository_dispatch: do-release` after merge — should publish v0.4.0 to RubyGems
