### PR TITLE
fix: V3 annotations end-to-end after upstream glossarist 2.10.1

### DIFF
--- a/lib/metanorma/plugin/glossarist/bibliography_renderer.rb
+++ b/lib/metanorma/plugin/glossarist/bibliography_renderer.rb
@@ -109,6 +109,7 @@ module Metanorma
           l10n.definition&.each { |d| parts << d.content.to_s }
           l10n.notes&.each { |n| parts << n.content.to_s }
           l10n.examples&.each { |e| parts << e.content.to_s }
+          l10n.data.annotations&.each { |a| parts << a.content.to_s }
           return [] if parts.empty?
 
           MentionExtractor.new(parts.join(" ")).bibliography_ids

--- a/metanorma-plugin-glossarist.gemspec
+++ b/metanorma-plugin-glossarist.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "asciidoctor"
-  spec.add_dependency "glossarist", "~> 2.8", ">= 2.9.0"
+  spec.add_dependency "glossarist", "~> 2.8", ">= 2.10.1"
   spec.add_dependency "liquid"
   spec.add_dependency "metanorma-utils"
   spec.metadata["rubygems_mfa_required"] = "true"

--- a/spec/fixtures/dataset-glossarist-v3/localized_concept/lc-1.1-eng.yaml
+++ b/spec/fixtures/dataset-glossarist-v3/localized_concept/lc-1.1-eng.yaml
@@ -11,7 +11,8 @@ data:
   examples:
   - content: This is an example.
   annotations:
-  - content: This concept is used as a parent in the test hierarchy.
+  - content: This concept is used as a parent in the test hierarchy. See <<iso_9999>>
+      for context.
   sources:
   - origin:
       ref:

--- a/spec/metanorma/plugin/glossarist/bibliography_renderer_spec.rb
+++ b/spec/metanorma/plugin/glossarist/bibliography_renderer_spec.rb
@@ -136,14 +136,17 @@ RSpec.describe Metanorma::Plugin::Glossarist::BibliographyRenderer do
       v3_collection = Glossarist::ManagedConceptCollection.new
       v3_collection.load_from_files("./spec/fixtures/dataset-glossarist-v3")
       concept = v3_collection.find { |c| c.data&.id == "1.1" }
-      l10n = concept.localization("eng")
 
-      annotations = l10n.data.annotations
-      skip "V3 annotations not parsed by this glossarist version" if annotations.empty?
+      annotations = concept.localization("eng").data.annotations
+      expect(annotations).not_to be_empty,
+                                 "V3 annotations failed to parse — check glossarist version"
 
-      renderer = described_class.new
-      xrefs = renderer.send(:extract_content_xrefs, l10n)
-      expect(xrefs).to include("ievtermbank")
+      bibliography = bibliography_with(
+        [{ "id" => "iso_9999", "reference" => "ISO 9999", "title" => "Test" }],
+      )
+      renderer = described_class.new(bibliography: bibliography)
+      output = renderer.render_all([concept])
+      expect(output).to include("[[[iso_9999,ISO 9999")
     end
 
     it "includes title from bibliography in formatted entry" do


### PR DESCRIPTION
## Summary

Closes the downstream follow-ups unblocked by upstream glossarist 2.10.1 (PR glossarist#197 / commit e6589e0), which fixed two `GlossaryStore` loader defects that silently dropped V3 fields when a dataset used the legacy split layout:

1. `detect_version` regex didn't match quoted `schema_version` values — fell through to `"2"` default.
2. `load_legacy_localizations` dispatched version 3 → base `LocalizedConcept` (no typed annotations).

Our TODO 15 diagnosis was wrong: concept-model 3.1.0 declares annotations on `LocalizedConcept` (via `gloss:hasAnnotation rdfs:domain gloss:LocalizedConcept`), not on `Concept`. glossarist-ruby modeled it correctly; only the loader stood in the way.

## Changes

- Bump glossarist floor to `>= 2.10.1`.
- Remove `"V3 annotations not parsed by this glossarist version"` skip — suite now runs clean (262 / 0 / 0 pending).
- Drop `renderer.send(:extract_content_xrefs, l10n)` (project rule: no `send` for private methods); rewritten through the public `render_all` API.
- `BibliographyRenderer#extract_content_xrefs` now walks `l10n.data.annotations` too (previously only definition/notes/examples).
- Fixture `lc-1.1-eng.yaml` annotation content updated to include `<<iso_9999>>` so the bibliography xref extraction has a real annotation-originated reference to resolve.
- Verified end-to-end: `_concept.liquid`'s `{% for annotation in l10n.data.annotations.definitions %}` block now emits `[NOTE]` blocks for the V3 fixture.

## Test plan

- [x] `bundle exec rspec` — 262 examples, 0 failures, 0 pending (first clean run; the V3-annotations spec was previously skipped)
- [x] `bundle exec rubocop` — 62 files, 0 offenses
- [ ] CI green on PR
- [ ] After merge, dispatch `repository_dispatch: do-release` for a patch release (this is a downstream-only change, no breaking dep floor bump)
