### PR TITLE
refactor: route non-verbal entities through GlossaryStore

### DIFF
--- a/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
+++ b/lib/metanorma/plugin/glossarist/dataset_preprocessor.rb
@@ -290,7 +290,7 @@ module Metanorma
           kind = :"#{match[1]}"
           dataset_name = match[2].strip
           collection = @registry.non_verbal_collection(dataset_name, kind)
-          return unless collection
+          return if collection.nil? || collection.empty?
 
           renderer = NonVerbalRenderer.new(collections: { kind => collection })
           rendered = renderer.render_kind(kind)

--- a/lib/metanorma/plugin/glossarist/dataset_registry.rb
+++ b/lib/metanorma/plugin/glossarist/dataset_registry.rb
@@ -14,20 +14,16 @@ module Metanorma
         BIBLIOGRAPHY_FILENAME = "bibliography.yaml"
         REGISTER_FILENAME = "register.yaml"
 
-        # Map of plural kind symbol → (collection class, subdirectory name).
-        # Adding a new non-verbal kind = adding one entry here. The accessor
-        # `{kind}_for` and loader are derived from this table.
-        NON_VERBAL_KINDS = {
-          figures: [::Glossarist::Collections::FigureCollection, "figures"],
-          tables: [::Glossarist::Collections::TableCollection, "tables"],
-          formulas: [::Glossarist::Collections::FormulaCollection, "formulas"],
-        }.freeze
+        # Non-verbal entity kinds exposed by GlossaryStore. Each kind
+        # matches a method on +GlossaryStore+ (+#figures+, +#tables+,
+        # +#formulas+) that returns an +Array<Figure|Table|Formula>+,
+        # lazily loaded from +{dataset_path}/{kind}/*.yaml+.
+        NON_VERBAL_KINDS = %i[figures tables formulas].freeze
 
         def initialize
           @stores = {}
           @registers = {}
           @bibliographies = {}
-          @non_verbal = {}
           @context_paths = {}
         end
 
@@ -90,35 +86,39 @@ module Metanorma
           store_for(path).concepts
         end
 
-        # Returns the typed NonVerbalCollection for a registered context
-        # (e.g. FigureCollection), or nil if the dataset has no such
-        # subdirectory. +kind+ is one of the keys of NON_VERBAL_KINDS.
+        # Returns the Array of dataset-level non-verbal entities of the
+        # given kind for a registered context (e.g. +Array<Glossarist::Figure>+),
+        # or +nil+ if the context isn't registered. Empty Array means the
+        # dataset has no +{kind}/+ subdirectory.
+        #
+        # +kind+ must be one of +NON_VERBAL_KINDS+. The kind symbol is the
+        # message sent to +GlossaryStore+ — adding a new kind requires both
+        # a GlossaryStore accessor and an entry here.
         def non_verbal_collection(context_name, kind)
-          unless NON_VERBAL_KINDS.key?(kind)
+          unless NON_VERBAL_KINDS.include?(kind)
             raise ArgumentError, "unknown non-verbal kind: #{kind.inspect}"
           end
 
           path = @context_paths[context_name]
           return nil unless path
 
-          collection_class, subdir = NON_VERBAL_KINDS.fetch(kind)
-          non_verbal_at(path, kind, subdir, collection_class)
+          store_for(path).public_send(kind)
         end
 
-        NON_VERBAL_KINDS.each_key do |kind|
+        NON_VERBAL_KINDS.each do |kind|
           define_method("#{kind}_for") do |context_name|
             non_verbal_collection(context_name, kind)
           end
         end
 
         # Returns all available non-verbal collections for a context as a
-        # hash keyed by kind symbol (e.g. +{ figures: FigureCollection }+).
+        # hash keyed by kind symbol (e.g. +{ figures: Array<Figure> }+).
         # Kinds whose subdirectory doesn't exist are omitted. Convenient
         # for building a NonVerbalRenderer in one call.
         def non_verbal_collections(context_name)
-          NON_VERBAL_KINDS.each_with_object({}) do |(kind, _), memo|
+          NON_VERBAL_KINDS.each_with_object({}) do |kind, memo|
             collection = non_verbal_collection(context_name, kind)
-            memo[kind] = collection if collection
+            memo[kind] = collection if collection && !collection.empty?
           end
         end
 
@@ -147,14 +147,6 @@ module Metanorma
             file = File.join(path, BIBLIOGRAPHY_FILENAME)
             ::Glossarist::BibliographyData.from_file(file)
           end
-        end
-
-        def non_verbal_at(path, kind, subdir, collection_class)
-          dir = File.join(path, subdir)
-          return nil unless File.directory?(dir)
-
-          @non_verbal[path] ||= {}
-          @non_verbal[path][kind] ||= collection_class.from_directory(dir)
         end
 
         def relative_file_path(document, file_path)

--- a/lib/metanorma/plugin/glossarist/non_verbal_renderer.rb
+++ b/lib/metanorma/plugin/glossarist/non_verbal_renderer.rb
@@ -11,6 +11,12 @@ module Metanorma
       # Per-kind formatting is delegated to a formatter class registered
       # in +FORMATTERS+. Adding a new kind = adding one formatter class
       # and one entry here; the dispatcher itself never changes shape.
+      #
+      # Collections are +Array<Figure|Table|Formula>+ as returned by
+      # +GlossaryStore#figures/#tables/#formulas+. Lookups by id
+      # (for concept→entity refs) use a lazily-built index that includes
+      # Figure subfigures, preserving the recursive +Figure#find_by_id+
+      # semantics of the previous Collection-based path.
       class NonVerbalRenderer
         FORMATTERS = {
           figures: NonVerbalFormatters::Figure,
@@ -18,13 +24,14 @@ module Metanorma
           formulas: NonVerbalFormatters::Formula,
         }.freeze
 
-        # @param collections [Hash{Symbol => NonVerbalCollection, nil}]
+        # @param collections [Hash{Symbol => Array<NonVerbalEntity>, nil}]
         #   one entry per non-verbal kind, e.g.
-        #   `{ figures: FigureCollection, tables: ..., formulas: ... }`.
+        #   `{ figures: Array<Glossarist::Figure>, ... }`.
         #   Missing or nil entries are silently skipped.
         def initialize(collections:, lang: "eng")
           @collections = collections
           @lang = lang
+          @indices = {}
         end
 
         # Render every entity in the named collection.
@@ -32,11 +39,10 @@ module Metanorma
         # @param kind [Symbol] key in FORMATTERS (e.g. +:figures+)
         # @return [String] AsciiDoc blocks joined by blank lines, or ""
         def render_kind(kind)
-          collection = @collections[kind]
-          return "" if collection.nil? || collection.entries.empty?
+          entities = @collections[kind]
+          return "" if entities.nil? || entities.empty?
 
-          entries = collection.entries
-          "#{entries.map { |e| format_one(kind, e) }.join("\n\n")}\n"
+          "#{entities.map { |e| format_one(kind, e) }.join("\n\n")}\n"
         end
 
         # Render the non-verbal entities referenced by a concept's
@@ -61,10 +67,7 @@ module Metanorma
         private
 
         def render_ref(kind, ref)
-          collection = @collections[kind]
-          return nil unless collection
-
-          entity = collection.by_id(ref.entity_id)
+          entity = index_for(kind)[ref.entity_id]
           return nil unless entity
 
           format_one(kind, entity)
@@ -77,6 +80,27 @@ module Metanorma
         def concept_refs(concept, kind)
           refs = concept.data&.public_send(kind)
           Array(refs)
+        end
+
+        # Lazily builds and caches a {id => entity} index for the named
+        # kind. Figures include their subfigures recursively; other kinds
+        # are flat by id. Returns {} for missing/empty collections so
+        # lookups naturally return nil.
+        def index_for(kind)
+          @indices[kind] ||= build_index(@collections[kind])
+        end
+
+        def build_index(entities)
+          return {} if entities.nil? || entities.empty?
+
+          entities.each_with_object({}) { |e, h| index_entity(h, e) }
+        end
+
+        def index_entity(index, entity)
+          index[entity.id] = entity
+          return unless entity.is_a?(::Glossarist::Figure)
+
+          Array(entity.subfigures).each { |sub| index_entity(index, sub) }
         end
       end
     end

--- a/metanorma-plugin-glossarist.gemspec
+++ b/metanorma-plugin-glossarist.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "asciidoctor"
-  spec.add_dependency "glossarist", "~> 2.8", ">= 2.10.1"
+  spec.add_dependency "glossarist", "~> 2.8", ">= 2.11.1"
   spec.add_dependency "liquid"
   spec.add_dependency "metanorma-utils"
   spec.metadata["rubygems_mfa_required"] = "true"

--- a/spec/metanorma/plugin/glossarist/dataset_registry_spec.rb
+++ b/spec/metanorma/plugin/glossarist/dataset_registry_spec.rb
@@ -171,34 +171,42 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetRegistry do
   end
 
   describe "#non_verbal_collection" do
-    it "loads a FigureCollection from a V3 dataset" do
+    it "loads figures from a V3 dataset via GlossaryStore" do
       registry = described_class.new
       registry.register(document_double, "ds:#{v3_path}")
       coll = registry.non_verbal_collection("ds", :figures)
-      expect(coll).to be_a(Glossarist::Collections::FigureCollection)
-      expect(coll.ids).to include("mixed-reflection")
+      expect(coll).to be_an(Array)
+      expect(coll).to all(be_a(Glossarist::Figure))
+      expect(coll.map(&:id)).to include("mixed-reflection")
     end
 
-    it "loads a TableCollection from a V3 dataset" do
+    it "loads tables from a V3 dataset via GlossaryStore" do
       registry = described_class.new
       registry.register(document_double, "ds:#{v3_path}")
       coll = registry.non_verbal_collection("ds", :tables)
-      expect(coll).to be_a(Glossarist::Collections::TableCollection)
-      expect(coll.ids).to include("unit-conversion")
+      expect(coll).to be_an(Array)
+      expect(coll).to all(be_a(Glossarist::Table))
+      expect(coll.map(&:id)).to include("unit-conversion")
     end
 
-    it "loads a FormulaCollection from a V3 dataset" do
+    it "loads formulas from a V3 dataset via GlossaryStore" do
       registry = described_class.new
       registry.register(document_double, "ds:#{v3_path}")
       coll = registry.non_verbal_collection("ds", :formulas)
-      expect(coll).to be_a(Glossarist::Collections::FormulaCollection)
-      expect(coll.ids).to include("wave-equation")
+      expect(coll).to be_an(Array)
+      expect(coll).to all(be_a(Glossarist::Formula))
+      expect(coll.map(&:id)).to include("wave-equation")
     end
 
-    it "returns nil when the subdirectory is absent" do
+    it "returns an empty Array when the subdirectory is absent" do
       registry = described_class.new
       registry.register(document_double, "ds:#{v2_path}")
-      expect(registry.non_verbal_collection("ds", :figures)).to be_nil
+      expect(registry.non_verbal_collection("ds", :figures)).to eq([])
+    end
+
+    it "returns nil when the context is unregistered" do
+      registry = described_class.new
+      expect(registry.non_verbal_collection("missing", :figures)).to be_nil
     end
 
     it "raises ArgumentError for an unknown kind" do
@@ -209,7 +217,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetRegistry do
       end.to raise_error(ArgumentError, /unknown non-verbal kind/)
     end
 
-    it "caches collections across calls" do
+    it "caches collections across calls via GlossaryStore" do
       registry = described_class.new
       registry.register(document_double, "ds:#{v3_path}")
       first = registry.non_verbal_collection("ds", :figures)
@@ -222,9 +230,9 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetRegistry do
     it "exposes figures_for, tables_for, formulas_for methods" do
       registry = described_class.new
       registry.register(document_double, "ds:#{v3_path}")
-      expect(registry.figures_for("ds")).to be_a(Glossarist::Collections::FigureCollection)
-      expect(registry.tables_for("ds")).to be_a(Glossarist::Collections::TableCollection)
-      expect(registry.formulas_for("ds")).to be_a(Glossarist::Collections::FormulaCollection)
+      expect(registry.figures_for("ds")).to be_an(Array)
+      expect(registry.tables_for("ds")).to be_an(Array)
+      expect(registry.formulas_for("ds")).to be_an(Array)
     end
   end
 
@@ -234,7 +242,7 @@ RSpec.describe Metanorma::Plugin::Glossarist::DatasetRegistry do
       registry.register(document_double, "ds:#{v3_path}")
       hash = registry.non_verbal_collections("ds")
       expect(hash.keys).to contain_exactly(:figures, :tables, :formulas)
-      expect(hash[:figures]).to be_a(Glossarist::Collections::FigureCollection)
+      expect(hash[:figures]).to be_an(Array)
     end
 
     it "returns empty hash when no subdirectories exist" do

--- a/spec/metanorma/plugin/glossarist/non_verbal_renderer_spec.rb
+++ b/spec/metanorma/plugin/glossarist/non_verbal_renderer_spec.rb
@@ -6,22 +6,25 @@ RSpec.describe Metanorma::Plugin::Glossarist::NonVerbalRenderer do
   end
   let(:all_collections) do
     {
-      figures: collection_for(:figures),
-      tables: collection_for(:tables),
-      formulas: collection_for(:formulas),
+      figures: entities_for(:figures),
+      tables: entities_for(:tables),
+      formulas: entities_for(:formulas),
     }
   end
 
-  def collection_class_for(kind)
-    {
-      figures: Glossarist::Collections::FigureCollection,
-      tables: Glossarist::Collections::TableCollection,
-      formulas: Glossarist::Collections::FormulaCollection,
-    }.fetch(kind)
+  # Mirror DatasetRegistry's production path: ask GlossaryStore for the
+  # lazy Array<Figure|Table|Formula>. This keeps the spec honest about
+  # the real public API the renderer consumes.
+  def store
+    @store ||= begin
+      s = Glossarist::GlossaryStore.new
+      s.load_directory(v3_path)
+      s
+    end
   end
 
-  def collection_for(kind)
-    collection_class_for(kind).from_directory(File.join(v3_path, kind.to_s))
+  def entities_for(kind)
+    store.public_send(kind)
   end
 
   describe "#render_kind" do
@@ -50,6 +53,11 @@ RSpec.describe Metanorma::Plugin::Glossarist::NonVerbalRenderer do
 
     it "returns empty string when collection is nil" do
       renderer = described_class.new(collections: {})
+      expect(renderer.render_kind(:figures)).to eq("")
+    end
+
+    it "returns empty string when collection is an empty Array" do
+      renderer = described_class.new(collections: { figures: [] })
       expect(renderer.render_kind(:figures)).to eq("")
     end
   end
@@ -93,6 +101,32 @@ RSpec.describe Metanorma::Plugin::Glossarist::NonVerbalRenderer do
       )
       renderer = described_class.new(collections: all_collections)
       expect(renderer.render_concept_refs(bare.first)).to eq("")
+    end
+
+    it "resolves a ref to a Figure subfigure via the lazy index" do
+      parent = Glossarist::Figure.new(
+        id: "parent-fig",
+        caption: { "eng" => "Parent" },
+        images: [Glossarist::FigureImage.new(src: "parent.svg", role: "vector")],
+        subfigures: [
+          Glossarist::Figure.new(
+            id: "child-subfig",
+            caption: { "eng" => "Child" },
+            images: [Glossarist::FigureImage.new(src: "child.svg", role: "vector")],
+          ),
+        ],
+      )
+      concept = Glossarist::ManagedConcept.new(
+        data: Glossarist::ManagedConceptData.new(
+          id: "test",
+          figures: [Glossarist::FigureReference.new(entity_id: "child-subfig")],
+        ),
+      )
+      renderer = described_class.new(collections: { figures: [parent] })
+
+      out = renderer.render_concept_refs(concept)
+      expect(out).to include("[[child-subfig]]")
+      expect(out).to include("image::child.svg")
     end
   end
 end


### PR DESCRIPTION
## Summary

Adopts glossarist 2.11.x's new `GlossaryStore#figures/#tables/#formulas` lazy accessors as the single source of truth for non-verbal entity loading. The plugin previously duplicated this with `Collections::*Collection.from_directory` calls — two loaders for the same data, no shared cache with the rest of the dataset load.

## Changes

- **`DatasetRegistry`**: `non_verbal_collection` now delegates to `store.public_send(kind)`. Drops the per-path `@non_verbal` cache and the `non_verbal_at` private helper. `NON_VERBAL_KINDS` simplified from a hash-of-tuples to a flat symbol list for validation only.
- **`NonVerbalRenderer`**: Accepts `Hash{Symbol => Array}`. Builds a lazy `{id => entity}` index per kind on first lookup. For `Figure`, the index walks `subfigures` recursively (preserving the prior `Collection#by_id` semantics for subfigure refs).
- **Return semantics**: Match GlossaryStore — `nil` for unregistered context, `[]` for missing subdir. Callers check `.empty?` rather than `nil?`.
- **Specs**: Updated to consume `Array<Glossarist::Figure|Table|Formula>` directly. Added a subfigure-ref spec locking in the recursive-index behavior. Renderer spec now loads via `GlossaryStore` to mirror production exactly.

## Architecture properties

- **Single source of truth**: GlossaryStore owns loading + caching. No duplicate code path.
- **OCP**: Adding a new entity kind = adding a `GlossaryStore` accessor + a `FORMATTERS` entry. Dispatcher shape never changes.
- **DRY**: One cache (in GlossaryStore), one index (in NonVerbalRenderer).
- **Encapsulation**: NonVerbalRenderer's index is private. DatasetRegistry delegates loading rather than reimplementing it.
- **Model-driven**: All entities are typed Glossarist model objects; the kind symbol corresponds by name to the GlossaryStore method.
- **No forbidden patterns**: no `double()`, no `send` for private methods, no `instance_variable_set/get`, no `respond_to?`, no `require_relative` for internal code.

## Test plan

- [x] `bundle exec rspec` — 265 examples, 0 failures, 0 pending (+3 new since v0.4.1)
- [x] `bundle exec rubocop` — 62 files, 0 offenses
- [ ] CI green on PR
- [ ] After merge, dispatch patch release
